### PR TITLE
Release 1.1.1: honor upload limit env vars, fix creature HP Max

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,12 +71,24 @@ SMTP_SECURE=false
 
 # ----------------------------------------------
 # File Upload Limits (in MB)
-# Nginx client_max_body_size must be >= the largest limit here.
+# Applied on restart — no rebuild needed. Invalid values fall back to the
+# defaults below and are logged as a warning at startup.
 # ----------------------------------------------
 MAX_MAP_SIZE_MB=50
 MAX_TOKEN_SIZE_MB=5
 MAX_AUDIO_SIZE_MB=20
 MAX_AVATAR_SIZE_MB=2
+
+# Request body cap for the bundled Nginx (client_max_body_size).
+# Must be >= the largest MAX_*_SIZE_MB above plus ~5 MB of multipart overhead,
+# or uploads fail with HTTP 413 before reaching the API.
+# Example: MAX_MAP_SIZE_MB=250 -> NGINX_MAX_BODY_SIZE=255M
+#
+# If you use an EXTERNAL proxy (Traefik, Caddy, host Nginx, Cloudflare Tunnel)
+# you must raise its body limit yourself — this variable only configures the
+# bundled Nginx. Note that Cloudflare-proxied requests (Tunnels included) are
+# capped at 100 MB on Free/Pro plans regardless of these settings.
+NGINX_MAX_BODY_SIZE=55M
 
 # ----------------------------------------------
 # Session Timeouts (in milliseconds)

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,14 @@ desktop.ini
 # ---- Docker -----------------------------------------------------------------
 .docker/
 
+# Local-only Compose overrides: test stacks, machine-specific ports, container
+# renames. `docker-compose.override.yml` is picked up automatically by Compose,
+# so it is the usual home for local tweaks that must never ship.
+# The committed docker-compose.yml and docker-compose.dev.yml are NOT matched.
+docker-compose.override.yml
+docker-compose.*.local.yml
+*.local.yml
+
 # ---- Secrets / keys / certs — never commit private key material ------------
 # Broad, repo-wide patterns so a key or alternately-named env file dropped
 # anywhere is caught. The committed *.env.example templates are NOT matched

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.1.1] — 2026-08-17
+
+A bug-fix release for two settings that looked configurable but weren't: upload size limits set in
+`.env`, and a creature's HP Max. No breaking changes, no database migration — update and restart.
+
+### Fixed
+
+- **Creature HP Max now saves.** Editing a custom creature's HP Max appeared to work but the value was never sent to the server, so reopening the creature always showed 10 again — hit points were not part of a creature stat block at all. HP is now stored with the creature, loaded back into the edit form, and used when placing the creature on a map (previously every creature placed as a 10 HP token regardless of its stat block)
+- **SRD monsters now carry their real hit points.** The SRD importer fetched each monster's HP and hit dice from Open5e and then discarded them. New imports include them, and re-running **Seed SRD** from the creature library backfills hit points onto SRD creatures already in your library — it only fills in the missing HP fields and never touches custom creatures. Stat blocks now display hit points alongside armor class
+- **Upload size limits set in `.env` are now actually applied.** `MAX_MAP_SIZE_MB`, `MAX_TOKEN_SIZE_MB`, `MAX_AUDIO_SIZE_MB`, and `MAX_AVATAR_SIZE_MB` were documented, passed into the container, and displayed in the admin panel — but never read: every limit was a hardcoded constant, so raising a limit had no effect and the admin panel reported values that didn't match `.env`. The backend now resolves all four at startup, the upload dialog and admin panel read the live values from the server, and the generic upload cap follows the largest configured limit (it previously capped *every* upload at 25 MB, below the documented 50 MB for maps)
+- Oversize uploads no longer produce the error "FILE files must be smaller than NaNMB"; the message now names the asset type and its real limit
+- Files dropped onto the upload dialog are validated against the asset type currently selected, not the one selected when the dialog opened
+- Avatars are checked against the server's avatar limit after cropping, instead of being rejected by the server after a 10 MB client-side check that never matched it
+
+### Changed
+
+- Default upload limits in code now match the documented defaults — MAP 50 MB and AUDIO 20 MB (previously 25 MB and 10 MB in code, while `.env.example`, the README, and the docs all advertised 50/20). Docker installs already passed these values, so only installs running without the environment variables see a change, and only as an increase
+- The bundled Nginx reads its `client_max_body_size` from the new **`NGINX_MAX_BODY_SIZE`** variable (default `55M`, i.e. today's behaviour), so a limit increase no longer requires editing `nginx/nginx.conf`. `docker-compose.yml` now mounts `nginx/nginx.conf` as an Nginx template; custom configs keep working unchanged
+- The backend logs its effective upload limits at startup, and warns when they exceed the proxy's body cap — including a note about Cloudflare's 100 MB cap on proxied requests (Tunnels included), which no application setting can raise
+- The upload dialog now shows the maximum size for the selected asset type up front, and the admin panel shows the body limit your reverse proxy needs
+
+### Added
+
+- `GET /api/config` — public endpoint returning the server's upload limits, so limit changes take effect on restart without rebuilding the frontend image
+- **`NGINX_MAX_BODY_SIZE`** environment variable (optional, defaults to `55M`) — sets the bundled Nginx request body cap without editing `nginx/nginx.conf`
+
+### Upgrading from 1.1.0
+
+`docker compose up -d --build` is all that is required — no migration, no configuration changes.
+
+Two optional follow-ups:
+- To give SRD monsters their hit points, open a campaign's creature library and click **Seed SRD**. It backfills HP onto the SRD creatures already in your library and leaves custom creatures alone.
+- If you raise a `MAX_*_SIZE_MB` above ~50 MB, also raise `NGINX_MAX_BODY_SIZE` (bundled Nginx) or your own proxy's body limit — the backend logs a warning at startup telling you the value it needs.
+
+---
+
 ## [1.1.0] — 2026-07-12
 
 A modernization release: faster and smoother real-time play, a redesigned resizable session workspace, a shared UI component layer, a hardened and restructured backend, and accessibility + polish throughout — with no breaking changes for existing installs.

--- a/README.md
+++ b/README.md
@@ -190,12 +190,14 @@ All runtime configuration is managed through the Admin dashboard after setup:
 
 ### Default Upload Limits
 
-| Type | Default |
-|------|---------|
-| Map images | 50 MB |
-| Token images | 5 MB |
-| Audio files | 20 MB |
-| Avatar images | 2 MB |
+| Type | Default | Environment variable |
+|------|---------|----------------------|
+| Map images | 50 MB | `MAX_MAP_SIZE_MB` |
+| Token images | 5 MB | `MAX_TOKEN_SIZE_MB` |
+| Audio files | 20 MB | `MAX_AUDIO_SIZE_MB` |
+| Avatar images | 2 MB | `MAX_AVATAR_SIZE_MB` |
+
+Set these in `.env` and restart — no rebuild needed. If you raise one, raise your reverse proxy's body limit to match (`NGINX_MAX_BODY_SIZE` for the bundled Nginx). See [Upload Size Limits](docs/DEPLOYMENT.md#upload-size-limits).
 
 ---
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -34,6 +34,9 @@ CORS_ORIGIN=http://localhost:3000
 
 # ----------------------------------------------
 # File Upload Limits (MB)
+# Applied on restart. Invalid values fall back to these defaults with a
+# warning at startup. Any reverse proxy in front must allow request bodies of
+# at least the largest value + ~5 MB (bundled Nginx: NGINX_MAX_BODY_SIZE).
 # ----------------------------------------------
 MAX_MAP_SIZE_MB=50
 MAX_TOKEN_SIZE_MB=5

--- a/backend/docs/API_DOCUMENTATION.yaml
+++ b/backend/docs/API_DOCUMENTATION.yaml
@@ -32,7 +32,7 @@ info:
     Real-time campaign features (token movement, dice, chat, initiative, etc.) use Socket.io.
     See the WebSocket section at the bottom of this document for the full event reference.
 
-  version: 1.1.0
+  version: 1.1.1
   contact:
     name: CozyVTT
     url: https://cozyvtt.com
@@ -113,6 +113,53 @@ paths:
                   timestamp:
                     type: string
                     format: date-time
+
+  # ============================================
+  # CLIENT CONFIG
+  # ============================================
+
+  /api/config:
+    get:
+      tags:
+        - Health
+      summary: Get public client configuration
+      description: |
+        Public endpoint — returns the upload size limits the server enforces,
+        derived from the `MAX_<TYPE>_SIZE_MB` environment variables. The SPA is
+        built ahead of time, so it reads the limits from here at runtime rather
+        than baking them into the bundle. No authentication required.
+      operationId: getClientConfig
+      security: []
+      responses:
+        '200':
+          description: Client configuration
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uploadLimits:
+                    type: object
+                    description: Maximum upload size in bytes, per asset type
+                    properties:
+                      MAP:
+                        type: integer
+                      TOKEN:
+                        type: integer
+                      AUDIO:
+                        type: integer
+                      AVATAR:
+                        type: integer
+                  maxUploadBytes:
+                    type: integer
+                    description: Largest configured limit — the cap enforced before the asset type is known
+              example:
+                uploadLimits:
+                  MAP: 52428800
+                  TOKEN: 5242880
+                  AUDIO: 20971520
+                  AVATAR: 2097152
+                maxUploadBytes: 52428800
 
   # ============================================
   # SETUP
@@ -2350,13 +2397,15 @@ paths:
         inspection (not just MIME header or extension) and rejected if the
         detected type doesn't match the declared `type`.
 
-        **File size limits** (admin-configurable per type, defaults shown):
-        | Type | Default limit |
-        |------|---------------|
-        | MAP    | 50 MB |
-        | TOKEN  | 5 MB |
-        | AUDIO  | 20 MB |
-        | AVATAR | 2 MB |
+        **File size limits** — set per type with the `MAX_<TYPE>_SIZE_MB`
+        environment variables (defaults shown). The effective values are
+        available from `GET /api/config`.
+        | Type | Env var | Default limit |
+        |------|---------|---------------|
+        | MAP    | `MAX_MAP_SIZE_MB`    | 50 MB |
+        | TOKEN  | `MAX_TOKEN_SIZE_MB`  | 5 MB |
+        | AUDIO  | `MAX_AUDIO_SIZE_MB`  | 20 MB |
+        | AVATAR | `MAX_AVATAR_SIZE_MB` | 2 MB |
 
         Image assets generate a 512×512 thumbnail server-side.
 
@@ -3952,6 +4001,11 @@ paths:
       description: |
         Fetch SRD creatures from Open5e and populate the library (DM only).
         Safe to call multiple times — existing SRD creatures are not duplicated.
+
+        Existing SRD creatures stored before hit points were tracked are updated
+        in place with `hpMax` / `hitDice`; only those missing keys are added, and
+        custom creatures are never modified.
+
         Returns 409 if seeding is already in progress.
       operationId: seedSrdCreatures
       security:
@@ -3968,9 +4022,19 @@ paths:
                 properties:
                   message:
                     type: string
+                  fetched:
+                    type: integer
+                    description: Monsters returned by Open5e
                   created:
                     type: integer
+                    description: New SRD creatures inserted
+                  updated:
+                    type: integer
+                    description: Existing SRD creatures backfilled with hit points
                   skipped:
+                    type: integer
+                    description: Existing SRD creatures left unchanged
+                  alreadyExisted:
                     type: integer
         '409':
           description: Seeding already in progress
@@ -5795,7 +5859,11 @@ components:
           nullable: true
         statBlock:
           type: object
-          description: Game-system-agnostic stat block (AC, HP, attacks, abilities, etc.)
+          description: |
+            Game-system-agnostic stat block. Common keys: `ac`, `hpMax`, `hitDice`,
+            `speed`, `abilities`, `traits`, `actions`. `hpMax` seeds the hit points
+            of tokens placed from this creature (defaults to 10 when absent, as on
+            stat blocks saved before hit points were tracked).
         size:
           type: object
           properties:

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cozyvtt-backend",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cozyvtt-backend",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "5.8",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozyvtt-backend",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "CozyVTT Backend - Self-hosted Virtual Tabletop",
   "main": "dist/server.js",
   "scripts": {

--- a/backend/src/middleware/fileValidation.ts
+++ b/backend/src/middleware/fileValidation.ts
@@ -2,7 +2,7 @@ import { Response, NextFunction } from 'express';
 import { fileTypeFromFile } from 'file-type';
 import fs from 'fs/promises';
 import path from 'path';
-import { AssetType, isAllowedMimeType, deleteFile } from '../utils/fileUtils';
+import { AssetType, isAllowedMimeType, deleteFile, getFileSizeLimit } from '../utils/fileUtils';
 import { UploadRequest } from './upload';
 import logger from '../utils/logger';
 
@@ -137,16 +137,9 @@ export async function validateFileSize(
     const stats = await fs.stat(filePath);
     const fileSizeInBytes = stats.size;
 
-    // Get size limit for asset type
+    // Get size limit for asset type (resolved from MAX_<TYPE>_SIZE_MB at startup)
     const assetType = req.assetType || 'MAP';
-    const limits = {
-      MAP: 25 * 1024 * 1024,      // 25 MB
-      TOKEN: 5 * 1024 * 1024,     // 5 MB
-      AUDIO: 10 * 1024 * 1024,    // 10 MB
-      AVATAR: 2 * 1024 * 1024,    // 2 MB
-    };
-
-    const limit = limits[assetType];
+    const limit = getFileSizeLimit(assetType);
 
     if (fileSizeInBytes > limit) {
       // Delete the file

--- a/backend/src/middleware/upload.ts
+++ b/backend/src/middleware/upload.ts
@@ -4,6 +4,8 @@ import { Request } from 'express';
 import {
   AssetType,
   AssetScope,
+  FILE_SIZE_LIMITS,
+  MAX_UPLOAD_BYTES,
   generateUniqueFilename,
   getFilePath,
   getFileSizeLimit,
@@ -143,11 +145,15 @@ export function setAssetMetadata(assetType: AssetType, scope: AssetScope = 'GLOB
  * Generic upload middleware that accepts all file types
  * Used when asset type is determined from request body
  * File type validation happens in subsequent middleware
+ *
+ * The cap is the largest configured per-type limit — multer runs before the
+ * asset type is known, so the exact per-type limit is enforced afterwards by
+ * validateFileSize() in middleware/fileValidation.ts.
  */
 export const uploadGeneric = multer({
   storage,
   limits: {
-    fileSize: 25 * 1024 * 1024, // Max 25MB (largest allowed size)
+    fileSize: MAX_UPLOAD_BYTES, // Largest MAX_<TYPE>_SIZE_MB configured
     files: 1, // Only allow one file per request
   },
   // No fileFilter - accept all files, validate in middleware
@@ -167,13 +173,20 @@ export const uploadAvatar = createUploadMiddleware('AVATAR');
 export function handleUploadError(err: any, req: any, res: any, next: any) {
   if (err instanceof multer.MulterError) {
     if (err.code === 'LIMIT_FILE_SIZE') {
-      const assetType = (req as UploadRequest).assetType || 'FILE';
-      const limit = getFileSizeLimit(assetType as AssetType);
+      // On the generic upload route multer aborts mid-stream, so req.assetType
+      // is not set yet. The client sends `type` before the file part, so fall
+      // back to the parsed body, then to a type-agnostic message.
+      const bodyType = typeof req.body?.type === 'string' ? req.body.type.toUpperCase() : undefined;
+      const assetType = (req as UploadRequest).assetType || bodyType;
+      const isKnownType = !!assetType && assetType in FILE_SIZE_LIMITS;
+      const limit = isKnownType ? getFileSizeLimit(assetType as AssetType) : MAX_UPLOAD_BYTES;
       const limitMB = (limit / (1024 * 1024)).toFixed(0);
 
       return res.status(400).json({
         error: 'File Too Large',
-        message: `${assetType} files must be smaller than ${limitMB}MB`,
+        message: isKnownType
+          ? `${assetType} files must be smaller than ${limitMB}MB`
+          : `File exceeds the maximum upload size of ${limitMB}MB`,
       });
     }
 

--- a/backend/src/routes/config.ts
+++ b/backend/src/routes/config.ts
@@ -1,0 +1,26 @@
+import { Router, Request, Response } from 'express';
+import { FILE_SIZE_LIMITS, MAX_UPLOAD_BYTES } from '../utils/fileUtils';
+
+const router = Router();
+
+/**
+ * Public client configuration
+ *
+ * The SPA is built at image-build time, so anything baked into the bundle needs
+ * a rebuild to change. Upload limits are served here instead, letting the
+ * MAX_<TYPE>_SIZE_MB environment variables take effect with a restart.
+ */
+
+/**
+ * GET /api/config
+ * Returns the upload limits the server enforces.
+ * Public endpoint — no authentication required, no sensitive values.
+ */
+router.get('/', (_req: Request, res: Response) => {
+  res.json({
+    uploadLimits: { ...FILE_SIZE_LIMITS },
+    maxUploadBytes: MAX_UPLOAD_BYTES,
+  });
+});
+
+export default router;

--- a/backend/src/scripts/seedCreatures.ts
+++ b/backend/src/scripts/seedCreatures.ts
@@ -17,6 +17,7 @@ async function main() {
 
   console.log(`Fetched: ${result.fetched}`);
   console.log(`Created: ${result.created}`);
+  console.log(`Updated (hit points backfilled): ${result.updated}`);
   console.log(`Skipped (already existed): ${result.skipped}`);
   console.log(`Previously in DB: ${result.alreadyExisted}`);
   console.log('\nDone. SRD creatures are available to all campaigns.');

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -21,9 +21,12 @@ import mapRoutes from './routes/maps';
 import creatureRoutes from './routes/creatures';
 import tokenTemplateRoutes from './routes/tokenTemplates';
 import adminRoutes from './routes/admin';
+import configRoutes from './routes/config';
 import { initializeWebSocket } from './websocket';
 import logger from './utils/logger';
 import { prisma } from './config/database';
+import { FILE_SIZE_LIMITS } from './utils/fileUtils';
+import { getProxyLimitWarnings } from './utils/proxyLimits';
 
 const app = express();
 const httpServer = createServer(app);
@@ -130,6 +133,9 @@ app.use('/api', generalApiLimiter);
 // Setup wizard (accessible before setup is complete)
 app.use('/api/setup', setupRoutes);
 
+// Public client configuration (upload limits)
+app.use('/api/config', configRoutes);
+
 // Authentication: login, register, password reset, MFA
 app.use('/api/auth', authRoutes);
 
@@ -195,6 +201,18 @@ httpServer.listen(PORT, () => {
   logger.info(`CozyVTT Backend running on port ${PORT}`);
   logger.info(`Environment: ${process.env.NODE_ENV || 'development'}`);
   logger.info(`CORS origin: ${process.env.CORS_ORIGIN || 'http://localhost:3000'}`);
+
+  const uploadLimits = Object.entries(FILE_SIZE_LIMITS)
+    .map(([type, bytes]) => `${type} ${Math.round(bytes / (1024 * 1024))}MB`)
+    .join(', ');
+  logger.info(`Upload limits: ${uploadLimits}`);
+
+  // A proxy body-size cap below the configured limits turns uploads into 413s
+  // that never reach this process — surface it at startup rather than in a
+  // bug report.
+  for (const warning of getProxyLimitWarnings()) {
+    logger.warn(warning);
+  }
 });
 
 export default app;

--- a/backend/src/services/campaignExporter.ts
+++ b/backend/src/services/campaignExporter.ts
@@ -197,7 +197,7 @@ export async function exportCampaign(
   const manifest = {
     formatVersion: 1,
     exportedAt: new Date().toISOString(),
-    exportedFrom: `CozyVTT v${process.env.npm_package_version || '1.1.0'}`,
+    exportedFrom: `CozyVTT v${process.env.npm_package_version || '1.1.1'}`,
     campaignName: campaign.name,
     gameSystem: campaign.gameSystem || 'NONE',
     mapCount: mapDataArray.length,

--- a/backend/src/services/creatureSeed.test.ts
+++ b/backend/src/services/creatureSeed.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Creature Seeding — Unit Tests
+ *
+ * Covers the hit-point mapping from Open5e and the backfill that adds HP to
+ * SRD stat blocks stored before hit points were tracked.
+ */
+
+import { transformMonster, backfillStatBlockHp } from './creatureSeed';
+
+/** Minimal Open5e monster — only the fields the transform reads. */
+const goblin = {
+  slug: 'goblin',
+  name: 'Goblin',
+  size: 'Small',
+  type: 'humanoid',
+  subtype: 'goblinoid',
+  group: null,
+  alignment: 'neutral evil',
+  armor_class: 15,
+  armor_desc: 'leather armor, shield',
+  hit_points: 7,
+  hit_dice: '2d6',
+  speed: { walk: 30 },
+  strength: 8,
+  dexterity: 14,
+  constitution: 10,
+  intelligence: 10,
+  wisdom: 8,
+  charisma: 8,
+  strength_save: null,
+  dexterity_save: null,
+  constitution_save: null,
+  intelligence_save: null,
+  wisdom_save: null,
+  charisma_save: null,
+  skills: { stealth: 6 },
+  senses: 'darkvision 60 ft., passive Perception 9',
+  languages: 'Common, Goblin',
+  challenge_rating: '1/4',
+  cr: 0.25,
+  actions: null,
+  bonus_actions: null,
+  reactions: null,
+  special_abilities: null,
+  legendary_desc: '',
+  legendary_actions: null,
+  damage_vulnerabilities: '',
+  damage_resistances: '',
+  damage_immunities: '',
+  condition_immunities: '',
+  document__slug: 'wotc-srd',
+  document__title: 'Systems Reference Document',
+} as unknown as Parameters<typeof transformMonster>[0];
+
+// ============================================
+// transformMonster
+// ============================================
+
+describe('transformMonster', () => {
+  it('maps Open5e hit points and hit dice into the stat block', () => {
+    const { statBlock } = transformMonster(goblin);
+
+    expect(statBlock.hpMax).toBe(7);
+    expect(statBlock.hitDice).toBe('2d6');
+  });
+
+  it('omits hit dice when Open5e provides none', () => {
+    const { statBlock } = transformMonster({ ...goblin, hit_dice: '' });
+
+    expect(statBlock.hpMax).toBe(7);
+    expect(statBlock.hitDice).toBeUndefined();
+  });
+
+  it('still maps the rest of the stat block', () => {
+    const { statBlock } = transformMonster(goblin);
+
+    expect(statBlock.ac).toBe(15);
+    expect(statBlock.speed).toBe('30 ft.');
+    expect(statBlock.abilities.dex).toBe(14);
+  });
+});
+
+// ============================================
+// backfillStatBlockHp
+// ============================================
+
+describe('backfillStatBlockHp', () => {
+  it('adds hit points to a stat block that has none', () => {
+    const result = backfillStatBlockHp({ ac: 15, speed: '30 ft.' }, 7, '2d6');
+
+    expect(result).toEqual({ ac: 15, speed: '30 ft.', hpMax: 7, hitDice: '2d6' });
+  });
+
+  it('leaves every other key untouched', () => {
+    const existing = {
+      ac: 15,
+      speed: '30 ft.',
+      actions: [{ name: 'Scimitar', description: 'Melee attack' }],
+      notes: 'DM-curated text',
+    };
+
+    const result = backfillStatBlockHp(existing, 7, '2d6');
+
+    expect(result!.actions).toEqual(existing.actions);
+    expect(result!.notes).toBe('DM-curated text');
+  });
+
+  it('returns null when the stat block already has hit points', () => {
+    expect(backfillStatBlockHp({ ac: 15, hpMax: 42 }, 7, '2d6')).toBeNull();
+  });
+
+  it('keeps existing hit dice rather than overwriting them', () => {
+    const result = backfillStatBlockHp({ ac: 15, hitDice: '3d6' }, 7, '2d6');
+
+    expect(result!.hitDice).toBe('3d6');
+    expect(result!.hpMax).toBe(7);
+  });
+
+  it('returns null for unusable stat blocks', () => {
+    expect(backfillStatBlockHp(null, 7)).toBeNull();
+    expect(backfillStatBlockHp(undefined, 7)).toBeNull();
+    expect(backfillStatBlockHp('not an object', 7)).toBeNull();
+    expect(backfillStatBlockHp([], 7)).toBeNull();
+  });
+});

--- a/backend/src/services/creatureSeed.ts
+++ b/backend/src/services/creatureSeed.ts
@@ -88,7 +88,7 @@ const CR_XP: Record<string, number> = {
 
 // ─── Transform Open5e monster to our stat block ─────────────────
 
-function transformMonster(m: Open5eMonster) {
+export function transformMonster(m: Open5eMonster) {
   const speedParts = Object.entries(m.speed)
     .map(([type, val]) => (type === 'walk' ? `${val} ft.` : `${type} ${val} ft.`));
   const speedStr = speedParts.join(', ') || '0 ft.';
@@ -107,6 +107,8 @@ function transformMonster(m: Open5eMonster) {
 
   const statBlock = {
     ac: m.armor_class,
+    hpMax: m.hit_points,
+    hitDice: m.hit_dice || undefined,
     speed: speedStr,
     abilities: {
       str: m.strength, dex: m.dexterity, con: m.constitution,
@@ -175,30 +177,78 @@ async function fetchAllSrdMonsters(): Promise<Open5eMonster[]> {
 export interface SeedResult {
   fetched: number;
   created: number;
+  updated: number;
   skipped: number;
   alreadyExisted: number;
 }
 
 /**
+ * Fill in hit points on a stat block that predates HP tracking.
+ *
+ * Returns null when the stat block already has HP (or is unusable), so callers
+ * can skip the write. Only the HP keys are added — every other key is copied
+ * through untouched, so a re-seed never rewrites curated stat block content.
+ */
+export function backfillStatBlockHp(
+  existingStatBlock: unknown,
+  hpMax: number,
+  hitDice?: string
+): Record<string, unknown> | null {
+  if (!existingStatBlock || typeof existingStatBlock !== 'object' || Array.isArray(existingStatBlock)) {
+    return null;
+  }
+
+  const statBlock = existingStatBlock as Record<string, unknown>;
+  if (typeof statBlock.hpMax === 'number') {
+    return null; // Already has HP — leave it alone
+  }
+
+  return {
+    ...statBlock,
+    hpMax,
+    ...(hitDice && !statBlock.hitDice && { hitDice }),
+  };
+}
+
+/**
  * Seed the CreatureTemplate table with D&D 5e SRD monsters from Open5e.
- * Safe to call multiple times — skips existing SRD creatures by name.
+ * Safe to call multiple times — existing SRD creatures are skipped, except that
+ * ones stored before hit points were tracked get their HP backfilled.
+ * Custom creatures are never touched.
  */
 export async function seedSrdCreatures(prisma: PrismaClient): Promise<SeedResult> {
-  // Check how many SRD creatures already exist
+  // Check which SRD creatures already exist (and whether they carry HP)
   const existing = await prisma.creatureTemplate.findMany({
     where: { source: 'srd' },
-    select: { name: true },
+    select: { id: true, name: true, statBlock: true },
   });
-  const existingNames = new Set(existing.map((e) => e.name));
+  const existingByName = new Map(existing.map((e) => [e.name, e]));
 
   // Fetch from Open5e
   const monsters = await fetchAllSrdMonsters();
 
   let created = 0;
+  let updated = 0;
   let skipped = 0;
 
   for (const monster of monsters) {
-    if (existingNames.has(monster.name)) {
+    const existingRow = existingByName.get(monster.name);
+    if (existingRow) {
+      // Pre-HP row: add the missing hit points, leaving the rest as it was
+      const patched = backfillStatBlockHp(existingRow.statBlock, monster.hit_points, monster.hit_dice);
+      if (patched) {
+        try {
+          await prisma.creatureTemplate.update({
+            where: { id: existingRow.id },
+            // `as object` matches how statBlock JSON is written elsewhere (routes/creatures.ts)
+            data: { statBlock: patched as object },
+          });
+          updated++;
+          continue;
+        } catch (err) {
+          logger.error(`Failed to backfill HP for "${monster.name}"`, { err: err });
+        }
+      }
       skipped++;
       continue;
     }
@@ -233,8 +283,9 @@ export async function seedSrdCreatures(prisma: PrismaClient): Promise<SeedResult
   return {
     fetched: monsters.length,
     created,
+    updated,
     skipped,
-    alreadyExisted: existingNames.size,
+    alreadyExisted: existingByName.size,
   };
 }
 

--- a/backend/src/utils/fileUtils.test.ts
+++ b/backend/src/utils/fileUtils.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Upload Size Limits — Unit Tests
+ *
+ * Covers the MAX_<TYPE>_SIZE_MB environment overrides that back
+ * FILE_SIZE_LIMITS, and the proxy body-size warnings derived from them.
+ */
+
+import { resolveFileSizeLimits, DEFAULT_FILE_SIZE_LIMITS_MB } from './fileUtils';
+import { parseProxyBodySize } from './proxyLimits';
+
+const MB = 1024 * 1024;
+
+// ============================================
+// resolveFileSizeLimits
+// ============================================
+
+describe('resolveFileSizeLimits', () => {
+  it('falls back to the documented defaults when nothing is set', () => {
+    const limits = resolveFileSizeLimits({});
+
+    expect(limits).toEqual({
+      MAP: DEFAULT_FILE_SIZE_LIMITS_MB.MAP * MB,
+      TOKEN: DEFAULT_FILE_SIZE_LIMITS_MB.TOKEN * MB,
+      AUDIO: DEFAULT_FILE_SIZE_LIMITS_MB.AUDIO * MB,
+      AVATAR: DEFAULT_FILE_SIZE_LIMITS_MB.AVATAR * MB,
+    });
+    expect(limits.MAP).toBe(50 * MB);
+    expect(limits.AUDIO).toBe(20 * MB);
+  });
+
+  it('applies each MAX_<TYPE>_SIZE_MB override', () => {
+    const limits = resolveFileSizeLimits({
+      MAX_MAP_SIZE_MB: '500',
+      MAX_TOKEN_SIZE_MB: '8',
+      MAX_AUDIO_SIZE_MB: '250',
+      MAX_AVATAR_SIZE_MB: '3',
+    });
+
+    expect(limits.MAP).toBe(500 * MB);
+    expect(limits.TOKEN).toBe(8 * MB);
+    expect(limits.AUDIO).toBe(250 * MB);
+    expect(limits.AVATAR).toBe(3 * MB);
+  });
+
+  it('overrides only the types that are set', () => {
+    const limits = resolveFileSizeLimits({ MAX_AUDIO_SIZE_MB: '250' });
+
+    expect(limits.AUDIO).toBe(250 * MB);
+    expect(limits.MAP).toBe(50 * MB);
+  });
+
+  it('treats an empty value as unset (docker-compose passes "" for unset vars)', () => {
+    const limits = resolveFileSizeLimits({ MAX_AUDIO_SIZE_MB: '', MAX_MAP_SIZE_MB: '   ' });
+
+    expect(limits.AUDIO).toBe(20 * MB);
+    expect(limits.MAP).toBe(50 * MB);
+  });
+
+  it('ignores invalid values instead of crashing', () => {
+    const limits = resolveFileSizeLimits({
+      MAX_MAP_SIZE_MB: '250mb',
+      MAX_TOKEN_SIZE_MB: '0',
+      MAX_AUDIO_SIZE_MB: '-5',
+      MAX_AVATAR_SIZE_MB: 'not-a-number',
+    });
+
+    expect(limits.MAP).toBe(50 * MB);
+    expect(limits.TOKEN).toBe(5 * MB);
+    expect(limits.AUDIO).toBe(20 * MB);
+    expect(limits.AVATAR).toBe(2 * MB);
+  });
+
+  it('accepts fractional megabytes', () => {
+    const limits = resolveFileSizeLimits({ MAX_AVATAR_SIZE_MB: '1.5' });
+
+    expect(limits.AVATAR).toBe(Math.round(1.5 * MB));
+  });
+});
+
+// ============================================
+// parseProxyBodySize
+// ============================================
+
+describe('parseProxyBodySize', () => {
+  it('parses Nginx size suffixes', () => {
+    expect(parseProxyBodySize('55M')).toBe(55 * MB);
+    expect(parseProxyBodySize('512k')).toBe(512 * 1024);
+    expect(parseProxyBodySize('1G')).toBe(1024 * MB);
+    expect(parseProxyBodySize('1048576')).toBe(1048576);
+  });
+
+  it('returns null for missing or malformed values', () => {
+    expect(parseProxyBodySize(undefined)).toBeNull();
+    expect(parseProxyBodySize('')).toBeNull();
+    expect(parseProxyBodySize('big')).toBeNull();
+    expect(parseProxyBodySize('0M')).toBeNull();
+  });
+});
+
+// ============================================
+// getProxyLimitWarnings
+//
+// Reloaded per case: the warnings are derived from the limits resolved at
+// module load, mirroring how the server sees them at startup.
+// ============================================
+
+describe('getProxyLimitWarnings', () => {
+  const originalEnv = process.env;
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.resetModules();
+  });
+
+  const loadWith = (env: Record<string, string>): string[] => {
+    process.env = { ...originalEnv, ...env };
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { getProxyLimitWarnings } = require('./proxyLimits');
+    return getProxyLimitWarnings(process.env);
+  };
+
+  it('stays quiet when the proxy limit covers the largest upload', () => {
+    expect(loadWith({ MAX_MAP_SIZE_MB: '50', NGINX_MAX_BODY_SIZE: '55M' })).toEqual([]);
+  });
+
+  it('warns when NGINX_MAX_BODY_SIZE is smaller than the largest limit', () => {
+    const warnings = loadWith({ MAX_AUDIO_SIZE_MB: '250', NGINX_MAX_BODY_SIZE: '55M' });
+
+    expect(warnings.some((w) => w.includes('NGINX_MAX_BODY_SIZE=255M'))).toBe(true);
+  });
+
+  it('warns about the Cloudflare 100 MB body cap for large limits', () => {
+    const warnings = loadWith({ MAX_AUDIO_SIZE_MB: '250', NGINX_MAX_BODY_SIZE: '300M' });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('Cloudflare');
+  });
+
+  it('warns when no proxy limit is configured and limits are large', () => {
+    const warnings = loadWith({ MAX_MAP_SIZE_MB: '80' });
+
+    expect(warnings.some((w) => w.includes('client_max_body_size 85M'))).toBe(true);
+  });
+});

--- a/backend/src/utils/fileUtils.ts
+++ b/backend/src/utils/fileUtils.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import path from 'path';
 import fs from 'fs/promises';
+import logger from './logger';
 
 /**
  * Asset types supported by the application
@@ -13,14 +14,71 @@ export type AssetType = 'MAP' | 'TOKEN' | 'AUDIO' | 'AVATAR';
 export type AssetScope = 'GLOBAL' | 'USER' | 'CAMPAIGN';
 
 /**
- * File size limits in bytes
+ * Default upload limits in MB, used when the matching env var is unset or invalid.
+ * These match .env.example, docker-compose.yml, README.md and docs/DEPLOYMENT.md.
  */
-export const FILE_SIZE_LIMITS = {
-  MAP: 25 * 1024 * 1024,      // 25 MB
-  TOKEN: 5 * 1024 * 1024,     // 5 MB
-  AUDIO: 10 * 1024 * 1024,    // 10 MB
-  AVATAR: 2 * 1024 * 1024,    // 2 MB
-} as const;
+export const DEFAULT_FILE_SIZE_LIMITS_MB: Record<AssetType, number> = {
+  MAP: 50,
+  TOKEN: 5,
+  AUDIO: 20,
+  AVATAR: 2,
+};
+
+const ASSET_TYPES: AssetType[] = ['MAP', 'TOKEN', 'AUDIO', 'AVATAR'];
+
+/**
+ * Resolve per-type upload limits (in bytes) from MAX_<TYPE>_SIZE_MB environment
+ * variables, falling back to DEFAULT_FILE_SIZE_LIMITS_MB.
+ *
+ * Invalid values (non-numeric, zero, negative) are ignored with a warning rather
+ * than crashing the server — a typo in .env must never prevent startup.
+ *
+ * Exported (with an injectable env) so it can be unit tested without mutating
+ * the real process environment.
+ */
+export function resolveFileSizeLimits(
+  env: NodeJS.ProcessEnv = process.env
+): Record<AssetType, number> {
+  const limits = {} as Record<AssetType, number>;
+
+  for (const assetType of ASSET_TYPES) {
+    const varName = `MAX_${assetType}_SIZE_MB`;
+    const raw = env[varName];
+    const fallbackMB = DEFAULT_FILE_SIZE_LIMITS_MB[assetType];
+    let sizeMB = fallbackMB;
+
+    if (raw !== undefined && raw.trim() !== '') {
+      const parsed = Number(raw.trim());
+
+      if (Number.isFinite(parsed) && parsed > 0) {
+        sizeMB = parsed;
+      } else {
+        logger.warn(
+          `Invalid ${varName}="${raw}" — expected a positive number of megabytes. Using default ${fallbackMB} MB.`
+        );
+      }
+    }
+
+    limits[assetType] = Math.round(sizeMB * 1024 * 1024);
+  }
+
+  return limits;
+}
+
+/**
+ * File size limits in bytes, resolved once at startup from the environment.
+ *
+ * NOTE: this reads process.env at module load, which is safe because
+ * src/server.ts calls dotenv.config() on its first lines, before any import
+ * that reaches this module. Keep that ordering intact.
+ */
+export const FILE_SIZE_LIMITS: Record<AssetType, number> = resolveFileSizeLimits();
+
+/**
+ * The largest configured limit — the cap for the generic multer instance that
+ * parses uploads before the asset type is known (see middleware/upload.ts).
+ */
+export const MAX_UPLOAD_BYTES: number = Math.max(...Object.values(FILE_SIZE_LIMITS));
 
 /**
  * Allowed MIME types for each asset type
@@ -160,10 +218,11 @@ export async function ensureDirectory(dirPath: string): Promise<void> {
 /**
  * Get file size limit for an asset type
  * @param assetType Type of asset
- * @returns Size limit in bytes
+ * @returns Size limit in bytes (falls back to the largest configured limit for
+ *          unknown types, so callers never end up formatting `undefined`)
  */
 export function getFileSizeLimit(assetType: AssetType): number {
-  return FILE_SIZE_LIMITS[assetType];
+  return FILE_SIZE_LIMITS[assetType] ?? MAX_UPLOAD_BYTES;
 }
 
 /**

--- a/backend/src/utils/proxyLimits.ts
+++ b/backend/src/utils/proxyLimits.ts
@@ -1,0 +1,92 @@
+/**
+ * Helpers for reasoning about the request-body cap of whatever proxy sits in
+ * front of CozyVTT.
+ *
+ * Upload limits are enforced by the app (MAX_<TYPE>_SIZE_MB), but a reverse
+ * proxy can reject a large upload with a 413 long before Express sees it. The
+ * bundled Nginx reads NGINX_MAX_BODY_SIZE; external proxies (Traefik, Caddy,
+ * Cloudflare Tunnel, a host-level Nginx) have to be configured by hand, so we
+ * warn about mismatches at startup instead of leaving users to guess.
+ */
+
+import { FILE_SIZE_LIMITS, MAX_UPLOAD_BYTES } from './fileUtils';
+
+const MB = 1024 * 1024;
+
+/** Multipart overhead: field parts, boundaries, base64-safe headroom. */
+export const UPLOAD_OVERHEAD_BYTES = 5 * MB;
+
+/**
+ * Cloudflare caps proxied request bodies at 100 MB on Free/Pro plans, and
+ * cloudflared tunnels inherit that cap.
+ */
+export const CLOUDFLARE_BODY_LIMIT_BYTES = 100 * MB;
+
+/**
+ * Parse an Nginx-style size ("55M", "512k", "1G", "1048576") into bytes.
+ * @returns bytes, or null when the value is missing or unparseable
+ */
+export function parseProxyBodySize(value?: string): number | null {
+  if (!value) return null;
+
+  const match = /^(\d+(?:\.\d+)?)\s*([kmg])?b?$/i.exec(value.trim());
+  if (!match) return null;
+
+  const amount = Number(match[1]);
+  if (!Number.isFinite(amount) || amount <= 0) return null;
+
+  const multipliers: Record<string, number> = { k: 1024, m: MB, g: 1024 * MB };
+  const unit = match[2]?.toLowerCase();
+
+  return Math.round(amount * (unit ? multipliers[unit] : 1));
+}
+
+/** Body size a proxy must accept to let the largest configured upload through. */
+export function getRequiredProxyBodyBytes(): number {
+  return MAX_UPLOAD_BYTES + UPLOAD_OVERHEAD_BYTES;
+}
+
+const toMB = (bytes: number) => Math.ceil(bytes / MB);
+
+/**
+ * Build startup warnings about proxy body-size caps that would block uploads.
+ * Pure and env-injectable so it can be unit tested.
+ */
+export function getProxyLimitWarnings(env: NodeJS.ProcessEnv = process.env): string[] {
+  const warnings: string[] = [];
+  const required = getRequiredProxyBodyBytes();
+  const requiredMB = toMB(required);
+  const largestType = (Object.keys(FILE_SIZE_LIMITS) as Array<keyof typeof FILE_SIZE_LIMITS>).find(
+    (type) => FILE_SIZE_LIMITS[type] === MAX_UPLOAD_BYTES
+  );
+  const largest = `${largestType} (${toMB(MAX_UPLOAD_BYTES)} MB)`;
+
+  const configured = parseProxyBodySize(env.NGINX_MAX_BODY_SIZE);
+
+  if (env.NGINX_MAX_BODY_SIZE && configured === null) {
+    warnings.push(
+      `Invalid NGINX_MAX_BODY_SIZE="${env.NGINX_MAX_BODY_SIZE}" — expected an Nginx size such as "55M". ` +
+        `Uploads may be rejected with HTTP 413 before reaching the API.`
+    );
+  } else if (configured !== null && configured < required) {
+    warnings.push(
+      `NGINX_MAX_BODY_SIZE=${env.NGINX_MAX_BODY_SIZE} is smaller than the largest upload limit ${largest}. ` +
+        `Uploads will fail with HTTP 413 at Nginx. Set NGINX_MAX_BODY_SIZE=${requiredMB}M or larger in .env and restart.`
+    );
+  } else if (configured === null && MAX_UPLOAD_BYTES > 50 * MB) {
+    warnings.push(
+      `Largest upload limit is ${largest}. Any reverse proxy in front of CozyVTT must allow request bodies ` +
+        `of at least ${requiredMB} MB (Nginx: client_max_body_size ${requiredMB}M) or uploads will fail with HTTP 413.`
+    );
+  }
+
+  if (MAX_UPLOAD_BYTES > CLOUDFLARE_BODY_LIMIT_BYTES) {
+    warnings.push(
+      `Largest upload limit is ${largest}, above Cloudflare's 100 MB request-body cap on Free/Pro plans. ` +
+        `If you serve CozyVTT through a Cloudflare Tunnel or the Cloudflare proxy, uploads above 100 MB will be ` +
+        `rejected at Cloudflare's edge regardless of this setting.`
+    );
+  }
+
+  return warnings;
+}

--- a/backend/src/validators/campaignImport.ts
+++ b/backend/src/validators/campaignImport.ts
@@ -45,6 +45,9 @@ const NameDescPairSchema = z.object({
 
 const StatBlockSchema = z.object({
   ac: z.number().int().min(0).max(99),
+  // Optional: archives exported before HP tracking have neither field
+  hpMax: z.number().int().min(1).max(99999).optional(),
+  hitDice: z.string().max(50).optional(),
   speed: z.string().max(500),
   abilities: z.object({
     str: z.number().int().min(0).max(30),

--- a/backend/src/validators/tokenTemplates.ts
+++ b/backend/src/validators/tokenTemplates.ts
@@ -20,6 +20,9 @@ const NameDescPairSchema = z.object({
 
 const NpcStatBlockSchema = z.object({
   ac: z.number().int().min(0).max(99),
+  // Optional: stat blocks created before HP tracking have neither field
+  hpMax: z.number().int().min(1).max(99999).optional(),
+  hitDice: z.string().max(50).optional(),
   speed: z.string().max(200),
   abilities: z.object({
     str: z.number().int().min(0).max(30),

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,6 +52,9 @@ services:
       MAX_TOKEN_SIZE_MB: ${MAX_TOKEN_SIZE_MB}
       MAX_AUDIO_SIZE_MB: ${MAX_AUDIO_SIZE_MB}
       MAX_AVATAR_SIZE_MB: ${MAX_AVATAR_SIZE_MB}
+      # No bundled Nginx in dev — Vite proxies directly to the backend, so this
+      # only affects the startup warning about proxy body caps.
+      NGINX_MAX_BODY_SIZE: ${NGINX_MAX_BODY_SIZE:-}
     ports:
       - "4000:4000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,9 @@ services:
       MAX_TOKEN_SIZE_MB: ${MAX_TOKEN_SIZE_MB:-5}
       MAX_AUDIO_SIZE_MB: ${MAX_AUDIO_SIZE_MB:-20}
       MAX_AVATAR_SIZE_MB: ${MAX_AVATAR_SIZE_MB:-2}
+      # Read-only here: lets the backend warn at startup when the Nginx body
+      # cap is smaller than the limits above (it is applied by the nginx service)
+      NGINX_MAX_BODY_SIZE: ${NGINX_MAX_BODY_SIZE:-55M}
       # Rate limiting
       RATE_LIMIT_MAX_REQUESTS: ${RATE_LIMIT_MAX_REQUESTS:-300}
     volumes:
@@ -122,13 +125,22 @@ services:
     depends_on:
       - frontend
       - backend
+    environment:
+      # Request body cap. Must be >= the largest MAX_*_SIZE_MB above plus a few
+      # MB of multipart overhead, or large uploads fail with HTTP 413.
+      NGINX_MAX_BODY_SIZE: ${NGINX_MAX_BODY_SIZE:-55M}
+      # Only substitute this one variable — without the filter, envsubst would
+      # also blank Nginx's own $host / $scheme / $proxy_add_x_forwarded_for.
+      NGINX_ENVSUBST_FILTER: "NGINX_MAX_BODY_SIZE"
     ports:
       # Change these if 80/443 are already in use on your host.
       # Example: HTTP_PORT=8080 in .env to access CozyVTT at http://yourserver:8080
       - "${HTTP_PORT:-80}:80"
       - "${HTTPS_PORT:-443}:443"
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      # Mounted as a template: the nginx image renders it to
+      # /etc/nginx/conf.d/default.conf at start, filling in NGINX_MAX_BODY_SIZE.
+      - ./nginx/nginx.conf:/etc/nginx/templates/default.conf.template:ro
       - ./nginx/certs:/etc/nginx/certs:ro  # Place your SSL certs here
     networks:
       - internal

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -20,10 +20,11 @@ The backend also ships a full **OpenAPI 3.0 specification** at `backend/docs/API
 10. [Asset Endpoints](#asset-endpoints)
 11. [Invitation Endpoints](#invitation-endpoints)
 12. [User & Admin Endpoints](#user--admin-endpoints)
-13. [Setup Endpoint](#setup-endpoint)
-14. [WebSocket Events](#websocket-events)
-15. [Error Responses](#error-responses)
-16. [Rate Limits](#rate-limits)
+13. [Config Endpoint](#config-endpoint)
+14. [Setup Endpoint](#setup-endpoint)
+15. [WebSocket Events](#websocket-events)
+16. [Error Responses](#error-responses)
+17. [Rate Limits](#rate-limits)
 
 ---
 
@@ -401,7 +402,7 @@ Upload a `.cozyvtt` archive and return its manifest preview without creating any
   "preview": {
     "formatVersion": 1,
     "exportedAt": "2026-04-18T12:00:00.000Z",
-    "exportedFrom": "CozyVTT v1.1.0",
+    "exportedFrom": "CozyVTT v1.1.1",
     "campaignName": "The Lost Mines",
     "gameSystem": "DND_5E",
     "mapCount": 5,
@@ -723,6 +724,20 @@ Check whether SRD creatures have been seeded. Any campaign member can check.
 
 Seed SRD creatures from Open5e (DM only). Safe to call multiple times — existing SRD creatures are not duplicated. Returns `409` if seeding is already in progress.
 
+SRD creatures stored before hit points were tracked are updated in place with `hpMax` and `hitDice`; only those missing keys are added, and custom creatures are never modified.
+
+**Response:**
+```json
+{
+  "message": "SRD creature seeding complete",
+  "fetched": 322,
+  "created": 0,
+  "updated": 322,
+  "skipped": 0,
+  "alreadyExisted": 322
+}
+```
+
 ---
 
 ## Asset Endpoints
@@ -986,6 +1001,29 @@ Delete a database backup file.
 ### `POST /api/admin/backups/restore` *(Admin only)*
 
 Restore a database backup. **Destructive — overwrites all current data.**
+
+---
+
+## Config Endpoint
+
+### `GET /api/config`
+
+Public. Returns the upload limits the server enforces, derived from the `MAX_<TYPE>_SIZE_MB` environment variables. The SPA reads these at runtime, so changing a limit takes a restart rather than a frontend rebuild.
+
+**Response:**
+```json
+{
+  "uploadLimits": {
+    "MAP": 52428800,
+    "TOKEN": 5242880,
+    "AUDIO": 20971520,
+    "AVATAR": 2097152
+  },
+  "maxUploadBytes": 52428800
+}
+```
+
+Sizes are in bytes. `maxUploadBytes` is the largest configured limit — the cap applied while parsing an upload, before the asset type is known. See [Upload Size Limits](DEPLOYMENT.md#upload-size-limits) for the environment variables and the matching reverse-proxy setting.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,6 +74,7 @@ src/
 │   ├── invitations.ts Campaign invitation lifecycle
 │   ├── mfa.ts         TOTP setup, verify, disable, backup codes
 │   ├── setup.ts       First-run setup wizard
+│   ├── config.ts      Public client config (upload limits)
 │   └── admin.ts       Admin: stats, settings, users, backups, logs
 ├── services/          Business logic (called by routes and WebSocket handlers)
 ├── validators/        Zod validation schemas (one per domain, incl. game-systems/)
@@ -91,6 +92,8 @@ src/
 │   ├── spirit-layer.ts   Spirit-layer + dynamic-lighting token filtering
 │   ├── serverRaycasting.ts  Server-side vision raycasting for lighting
 │   ├── asset-urls.ts     Asset URL normalization
+│   ├── fileUtils.ts      Upload paths + MAX_*_SIZE_MB limit resolution
+│   ├── proxyLimits.ts    Proxy body-cap parsing and startup warnings
 │   └── logger.ts         Winston logger configuration
 └── types/             Shared TypeScript interfaces
 ```

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -166,7 +166,9 @@ Whatever proxy you use, it must:
 - Forward `/api/*` and `/socket.io/*` to the backend
 - Support WebSocket upgrades (`Upgrade: websocket` / `Connection: upgrade`) on the `/socket.io/` path
 - Pass `X-Forwarded-For` and `X-Forwarded-Proto` headers to the backend
-- Allow request bodies of at least **55 MB** (covers the default `MAX_MAP_SIZE_MB=50` plus overhead)
+- Allow request bodies of at least **55 MB** (covers the default `MAX_MAP_SIZE_MB=50` plus overhead), and more if you raise any `MAX_*_SIZE_MB` — see [Upload Size Limits](#upload-size-limits)
+
+> ⚠️ **Cloudflare users:** Cloudflare-proxied requests — including Cloudflare Tunnel — are capped at **100 MB** per request body on Free and Pro plans. Uploads above that are rejected at Cloudflare's edge no matter how CozyVTT or your proxy is configured.
 
 ---
 
@@ -305,6 +307,7 @@ server {
     add_header X-Frame-Options SAMEORIGIN always;
     add_header Referrer-Policy strict-origin-when-cross-origin always;
 
+    # Must be >= the largest MAX_*_SIZE_MB in .env, plus a few MB of overhead
     client_max_body_size 55M;
 
     # API → backend
@@ -379,9 +382,32 @@ MAX_MAP_SIZE_MB=50
 MAX_TOKEN_SIZE_MB=5
 MAX_AUDIO_SIZE_MB=20
 MAX_AVATAR_SIZE_MB=2
+
+# Request body cap for the bundled Nginx — must be >= the largest limit above
+# plus ~5 MB of multipart overhead
+NGINX_MAX_BODY_SIZE=55M
 ```
 
-If you increase any of these, also update `client_max_body_size` in your Nginx config to match or exceed the largest value.
+These take effect on `docker compose up -d` (no image rebuild needed): the backend enforces them, and the app fetches them at runtime for the admin panel and the upload dialog. Values that aren't a positive number are ignored, with a warning in the backend log.
+
+**If you raise a limit, raise the proxy limit too.** A file larger than the proxy's body cap is rejected with an HTTP 413 before it ever reaches CozyVTT:
+
+| Setup | What to change |
+|---|---|
+| Bundled Nginx (default `docker-compose.yml`) | Set `NGINX_MAX_BODY_SIZE` in `.env`, then `docker compose up -d` |
+| Your own Nginx | `client_max_body_size` in your server block |
+| Traefik | `buffering.maxRequestBodyBytes` middleware (defaults to unlimited) |
+| Caddy | `request_body { max_size ... }` |
+| Cloudflare proxy / Tunnel | Hard 100 MB cap on Free/Pro — not configurable |
+
+The backend logs its effective limits at startup and warns when they exceed the configured proxy cap:
+
+```
+Upload limits: MAP 50MB, TOKEN 5MB, AUDIO 250MB, AVATAR 2MB
+NGINX_MAX_BODY_SIZE=55M is smaller than the largest upload limit AUDIO (250 MB). ...
+```
+
+The admin panel shows the same numbers under **Settings → Upload Size Limits**, along with the body size your proxy needs.
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -100,7 +100,10 @@ Copy `backend/.env.example` to `backend/.env` and fill in the values.
 | `MAX_TOKEN_SIZE_MB` | No | `5` | Upload size limit for token images |
 | `MAX_AUDIO_SIZE_MB` | No | `20` | Upload size limit for audio files |
 | `MAX_AVATAR_SIZE_MB` | No | `2` | Upload size limit for avatar images |
+| `NGINX_MAX_BODY_SIZE` | No | `55M` | Request body cap for the bundled Nginx (`client_max_body_size`); must cover the largest limit above |
 | `ASSET_UPLOAD_RATE_LIMIT` | No | `30` | Asset uploads per minute per user |
+
+The `MAX_*_SIZE_MB` values are read at startup by `backend/src/utils/fileUtils.ts` and served to the SPA by `GET /api/config`, so a restart is enough to change them — no rebuild. Non-numeric or non-positive values are ignored with a startup warning.
 
 **Example `backend/.env` for local development:**
 

--- a/docs/DM_GUIDE.md
+++ b/docs/DM_GUIDE.md
@@ -236,6 +236,7 @@ The first time you open the Creature Library in a new campaign, it may be empty.
 - Seeding takes a few seconds — a progress indicator shows while it runs
 - SRD creatures are **global** (shared across all campaigns on the instance) and **read-only**
 - You can duplicate any SRD creature to create an editable custom version
+- Running it again is safe: existing creatures are not duplicated. If your library was seeded before CozyVTT 1.1.1, re-running it fills in each SRD creature's hit points; custom creatures are never modified
 
 ### Browsing and Searching
 
@@ -260,6 +261,7 @@ Click any creature in the library to expand its details, then click **Place on M
 
 - The creature's name
 - Its stat block (viewable and editable in the Quick Editor)
+- Its hit points, taken from the stat block's **HP Max** (creatures with no HP recorded start at 10 — adjust in the Quick Editor)
 - Its image (if one has been associated)
 - Default disposition from the template (hostile, friendly, or neutral)
 - Display mode from the template (pog, top-down, or full-art)
@@ -269,7 +271,8 @@ Click any creature in the library to expand its details, then click **Place on M
 Click **+ New Creature** at the top of the Creature Library to create a custom creature template. Fill in:
 
 - **Name** — Required
-- **Stat Block** — The creature's combat stats (HP, AC, attacks, etc.)
+- **Stat Block** — The creature's combat stats (AC, speed, ability scores, attacks, etc.)
+- **HP Max** — Hit points given to tokens placed from this creature
 - **Challenge Rating** — Optional, used for filtering
 - **Creature Type** — Optional (e.g., beast, undead, fiend)
 - **Image** — Optional; choose from your TOKEN assets

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cozyvtt-frontend",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cozyvtt-frontend",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@tanstack/react-query": "^5.101.2",
         "axios": "^1.6.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozyvtt-frontend",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "CozyVTT Frontend - Self-hosted Virtual Tabletop",
   "private": true,

--- a/frontend/src/components/assets/AssetUploadModal.tsx
+++ b/frontend/src/components/assets/AssetUploadModal.tsx
@@ -6,6 +6,8 @@ import { Asset, AssetType, AssetScope, PlatformRole, Campaign, CampaignRole } fr
 import { useAuth } from '../../contexts/AuthContext';
 import campaignService from '../../services/campaign.service';
 import { Button, Modal } from '@/components/ui';
+import { useServerConfigQuery } from '@/hooks/queries';
+import { getUploadLimit, formatUploadLimit } from '@/utils/uploadLimits';
 
 interface AssetUploadModalProps {
   isOpen: boolean;
@@ -25,6 +27,7 @@ interface AssetUploadModalProps {
  */
 export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultType, defaultScope, defaultCampaignId }: AssetUploadModalProps) {
   const { user } = useAuth();
+  const { data: serverConfig } = useServerConfigQuery();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -120,27 +123,10 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
     setIsDragging(false);
   }, []);
 
-  const handleDrop = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragging(false);
-
-    const files = Array.from(e.dataTransfer.files);
-    if (files.length > 0) {
-      handleFileSelection(files[0]);
-    }
-  }, []);
-
   // Validate file based on asset type
   const validateFile = (file: File, type: AssetType): string | null => {
-    const maxSizes: Record<AssetType, number> = {
-      [AssetType.MAP]: 25 * 1024 * 1024,
-      [AssetType.TOKEN]: 5 * 1024 * 1024,
-      [AssetType.AUDIO]: 10 * 1024 * 1024,
-      [AssetType.AVATAR]: 2 * 1024 * 1024,
-      [AssetType.DOCUMENT]: 10 * 1024 * 1024,
-      [AssetType.OTHER]: 10 * 1024 * 1024,
-    };
+    // Server-configured limit (MAX_<TYPE>_SIZE_MB), with a local fallback
+    const maxSize = getUploadLimit(serverConfig, type);
 
     const allowedTypes: Record<AssetType, string[]> = {
       [AssetType.MAP]: ['image/jpeg', 'image/png', 'image/webp'],
@@ -151,8 +137,8 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
       [AssetType.OTHER]: [],
     };
 
-    if (file.size > maxSizes[type]) {
-      return `File size exceeds maximum of ${maxSizes[type] / (1024 * 1024)}MB`;
+    if (file.size > maxSize) {
+      return `File size exceeds maximum of ${formatUploadLimit(maxSize)}`;
     }
 
     const allowed = allowedTypes[type];
@@ -175,6 +161,19 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
 
     if (!name) {
       setName(file.name.replace(/\.[^/.]+$/, ''));
+    }
+  };
+
+  // Not memoized: it must see the current asset type and limits, otherwise
+  // dropped files are validated against whatever type was selected on mount.
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+
+    const files = Array.from(e.dataTransfer.files);
+    if (files.length > 0) {
+      handleFileSelection(files[0]);
     }
   };
 
@@ -220,8 +219,10 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
     setUploadProgress(0);
 
     try {
+      // Metadata first, file last: multer parses parts in order, so the server
+      // knows the asset type even when it aborts an oversize file mid-stream
+      // and can name the type and its limit in the error.
       const formData = new FormData();
-      formData.append('file', selectedFile);
       formData.append('type', assetType);
       formData.append('scope', assetScope);
       formData.append('name', name.trim());
@@ -234,6 +235,7 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
       if (assetScope === AssetScope.CAMPAIGN && selectedCampaignId) {
         formData.append('campaignId', selectedCampaignId);
       }
+      formData.append('file', selectedFile);
 
       const progressInterval = setInterval(() => {
         setUploadProgress((prev) => Math.min(prev + 10, 90));
@@ -428,6 +430,9 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
             <div>
               <label className="block text-sm font-medium text-moss-green mb-2">
                 File
+                <span className="ml-2 font-normal text-xs text-stone-gray/70">
+                  max {formatUploadLimit(getUploadLimit(serverConfig, assetType))}
+                </span>
               </label>
               <div
                 onDragOver={handleDragOver}

--- a/frontend/src/components/campaign/CreatureLibrary.tsx
+++ b/frontend/src/components/campaign/CreatureLibrary.tsx
@@ -31,6 +31,8 @@ import type { CreatureTemplate, NpcStatBlock } from '@/types';
 import { TokenType, GameSystem, AssetType, AssetScope } from '@/types';
 import { StatBlockViewer } from './npc-stat-blocks';
 import Button from '@/components/ui/Button';
+import { useServerConfigQuery } from '@/hooks/queries';
+import { getUploadLimit, formatUploadLimit } from '@/utils/uploadLimits';
 
 // ============================================
 // Constants
@@ -167,7 +169,10 @@ export default function CreatureLibrary({ isOpen, onClose }: CreatureLibraryProp
 
     try {
       const result = await api.seedSrdCreatures(campaign.id);
-      setSeedResult(`Seeded ${result.created} SRD creatures (${result.skipped} already existed).`);
+      const updatedNote = result.updated ? `, ${result.updated} updated with hit points` : '';
+      setSeedResult(
+        `Seeded ${result.created} SRD creatures${updatedNote} (${result.skipped} already existed).`
+      );
       setSrdCount((result.alreadyExisted || 0) + result.created);
       // Refresh the list
       fetchCreatures(true);
@@ -188,8 +193,9 @@ export default function CreatureLibrary({ isOpen, onClose }: CreatureLibraryProp
       y: Math.floor(currentMap.height / 2),
     };
 
-    // Default HP — DM can adjust after placement via NpcQuickEditor
-    const hpMax = 10;
+    // HP from the creature's stat block; creatures saved before HP was tracked
+    // fall back to 10, which the DM can adjust via NpcQuickEditor
+    const hpMax = creature.statBlock?.hpMax ?? 10;
 
     try {
       const tokenPayload = {
@@ -824,6 +830,7 @@ interface CreatureFormProps {
 function CreatureForm({ campaignId, gameSystem, editingCreature, onCreated, onEdited, onCancel }: CreatureFormProps) {
   const isEdit = !!editingCreature;
   const sb = editingCreature?.statBlock;
+  const { data: serverConfig } = useServerConfigQuery();
 
   // ── Basic fields ──
   const [name, setName] = useState(editingCreature?.name ?? '');
@@ -832,7 +839,7 @@ function CreatureForm({ campaignId, gameSystem, editingCreature, onCreated, onEd
   const [cr, setCr] = useState(editingCreature?.challengeRating ?? sb?.challengeRating ?? '');
   const [ac, setAc] = useState(sb?.ac ?? 10);
   const [speed, setSpeed] = useState(sb?.speed ?? '30 ft.');
-  const [hpMax, setHpMax] = useState(10);
+  const [hpMax, setHpMax] = useState(sb?.hpMax ?? 10);
   const [str, setStr] = useState(sb?.abilities?.str ?? 10);
   const [dex, setDex] = useState(sb?.abilities?.dex ?? 10);
   const [con, setCon] = useState(sb?.abilities?.con ?? 10);
@@ -870,21 +877,24 @@ function CreatureForm({ campaignId, gameSystem, editingCreature, onCreated, onEd
     const file = e.target.files?.[0];
     if (!file) return;
 
-    // Client-side size check
-    if (file.size > 5 * 1024 * 1024) {
-      setFormError('Image must be under 5 MB');
+    // Client-side size check against the server's token limit
+    const tokenLimit = getUploadLimit(serverConfig, AssetType.TOKEN);
+    if (file.size > tokenLimit) {
+      setFormError(`Image must be under ${formatUploadLimit(tokenLimit)}`);
       return;
     }
 
     setIsUploading(true);
     setFormError(null);
     try {
+      // Fields before the file: multer parses in order, so the server knows the
+      // asset type even when it aborts a too-large file mid-stream.
       const formData = new FormData();
-      formData.append('file', file);
       formData.append('type', AssetType.TOKEN);
       formData.append('scope', AssetScope.CAMPAIGN);
       formData.append('campaignId', campaignId);
       formData.append('name', file.name.replace(/\.[^.]+$/, ''));
+      formData.append('file', file);
 
       const { asset } = await api.uploadAsset(formData);
       setImageUrl(asset.id);
@@ -911,6 +921,10 @@ function CreatureForm({ campaignId, gameSystem, editingCreature, onCreated, onEd
 
     const statBlock: NpcStatBlock = {
       ac,
+      hpMax,
+      // Preserve hit dice from the source stat block (e.g. an SRD duplicate) —
+      // the form has no field for it, so it would otherwise be lost on save.
+      ...(sb?.hitDice && { hitDice: sb.hitDice }),
       speed,
       abilities: { str, dex, con, int, wis, cha },
       creatureType: creatureType || undefined,
@@ -1077,7 +1091,8 @@ function CreatureForm({ campaignId, gameSystem, editingCreature, onCreated, onEd
           <input
             type="number"
             value={hpMax}
-            onChange={(e) => setHpMax(parseInt(e.target.value, 10) || 1)}
+            onChange={(e) => setHpMax(Math.max(1, parseInt(e.target.value, 10) || 1))}
+            min={1}
             className="input-cozy w-full text-xs"
           />
         </div>

--- a/frontend/src/components/campaign/TokenTemplateLibrary.tsx
+++ b/frontend/src/components/campaign/TokenTemplateLibrary.tsx
@@ -29,6 +29,8 @@ import { TokenType, AssetType, AssetScope, CampaignRole } from '@/types';
 import type { TokenDisplayMode } from '@/types';
 import StatBlockEditor from './npc-stat-blocks/StatBlockEditor';
 import Button from '@/components/ui/Button';
+import { useServerConfigQuery } from '@/hooks/queries';
+import { getUploadLimit, formatUploadLimit } from '@/utils/uploadLimits';
 
 function defaultStatBlockForNpc(): NpcStatBlock {
   return {
@@ -500,6 +502,7 @@ interface TemplateFormProps {
 
 function TemplateForm({ campaignId, editingTemplate, onCreated, onEdited, onCancel }: TemplateFormProps) {
   const isEdit = !!editingTemplate;
+  const { data: serverConfig } = useServerConfigQuery();
 
   const [name, setName] = useState(editingTemplate?.name ?? '');
   const [type, setType] = useState<string>(editingTemplate?.type ?? 'object');
@@ -524,17 +527,20 @@ function TemplateForm({ campaignId, editingTemplate, onCreated, onEdited, onCanc
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    if (file.size > 5 * 1024 * 1024) { setFormError('Image must be under 5 MB'); return; }
+    const tokenLimit = getUploadLimit(serverConfig, AssetType.TOKEN);
+    if (file.size > tokenLimit) { setFormError(`Image must be under ${formatUploadLimit(tokenLimit)}`); return; }
 
     setIsUploading(true);
     setFormError(null);
     try {
+      // Fields before the file so the server can name the type if it rejects an
+      // oversize upload mid-stream.
       const formData = new FormData();
-      formData.append('file', file);
       formData.append('type', AssetType.TOKEN);
       formData.append('scope', AssetScope.CAMPAIGN);
       formData.append('campaignId', campaignId);
       formData.append('name', file.name.replace(/\.[^.]+$/, ''));
+      formData.append('file', file);
       const { asset } = await api.uploadAsset(formData);
       setImageUrl(asset.id);
     } catch {

--- a/frontend/src/components/campaign/npc-stat-blocks/Dnd5eStatBlock.tsx
+++ b/frontend/src/components/campaign/npc-stat-blocks/Dnd5eStatBlock.tsx
@@ -31,6 +31,12 @@ export default function Dnd5eStatBlock({ statBlock, tokenName }: Props) {
       {/* ── Core stats ── */}
       <div className="border-b border-amber-700/20 pb-1.5 space-y-0.5">
         <div><span className="font-semibold text-amber-900">Armor Class</span> {statBlock.ac}</div>
+        {statBlock.hpMax != null && (
+          <div>
+            <span className="font-semibold text-amber-900">Hit Points</span> {statBlock.hpMax}
+            {statBlock.hitDice && ` (${statBlock.hitDice})`}
+          </div>
+        )}
         <div><span className="font-semibold text-amber-900">Speed</span> {statBlock.speed}</div>
         {statBlock.challengeRating && (
           <div>

--- a/frontend/src/components/campaign/npc-stat-blocks/GenericStatBlock.tsx
+++ b/frontend/src/components/campaign/npc-stat-blocks/GenericStatBlock.tsx
@@ -31,6 +31,12 @@ export default function GenericStatBlock({ statBlock, tokenName }: Props) {
       {/* Core stats */}
       <div className="flex gap-4 flex-wrap">
         <div><span className="font-semibold text-moss-green">AC</span> {statBlock.ac}</div>
+        {statBlock.hpMax != null && (
+          <div>
+            <span className="font-semibold text-moss-green">HP</span> {statBlock.hpMax}
+            {statBlock.hitDice && ` (${statBlock.hitDice})`}
+          </div>
+        )}
         <div><span className="font-semibold text-moss-green">Speed</span> {statBlock.speed}</div>
         {statBlock.challengeRating && (
           <div>

--- a/frontend/src/components/campaign/npc-stat-blocks/StatBlockViewer.tsx
+++ b/frontend/src/components/campaign/npc-stat-blocks/StatBlockViewer.tsx
@@ -53,6 +53,12 @@ function Pf2eStatBlock({ statBlock, tokenName }: { statBlock: NpcStatBlock; toke
           <div><span className="font-semibold text-red-800">Level</span> {statBlock.challengeRating}</div>
         )}
         <div><span className="font-semibold text-red-800">AC</span> {statBlock.ac}</div>
+        {statBlock.hpMax != null && (
+          <div>
+            <span className="font-semibold text-red-800">HP</span> {statBlock.hpMax}
+            {statBlock.hitDice && ` (${statBlock.hitDice})`}
+          </div>
+        )}
         <div><span className="font-semibold text-red-800">Speed</span> {statBlock.speed}</div>
       </div>
 
@@ -105,6 +111,9 @@ function CoCStatBlock({ statBlock, tokenName }: { statBlock: NpcStatBlock; token
       {/* Combat stats */}
       <div className="flex gap-4 flex-wrap text-stone-700">
         <div><span className="font-semibold text-emerald-800">Armor</span> {statBlock.ac}</div>
+        {statBlock.hpMax != null && (
+          <div><span className="font-semibold text-emerald-800">HP</span> {statBlock.hpMax}</div>
+        )}
         <div><span className="font-semibold text-emerald-800">Move</span> {statBlock.speed}</div>
       </div>
 

--- a/frontend/src/components/character-sheets/dnd5e/DnD5eCharacterEditor.tsx
+++ b/frontend/src/components/character-sheets/dnd5e/DnD5eCharacterEditor.tsx
@@ -18,8 +18,10 @@ import {
   Upload,
   Palette,
 } from 'lucide-react';
-import { Character } from '../../../types';
+import { Character, AssetType } from '../../../types';
 import { api } from '../../../services/api';
+import { useServerConfigQuery } from '@/hooks/queries';
+import { getUploadLimit, formatUploadLimit } from '@/utils/uploadLimits';
 
 interface DnD5eCharacterEditorProps {
   character: Character;
@@ -106,6 +108,7 @@ export const DnD5eCharacterEditor: React.FC<DnD5eCharacterEditorProps> = ({
   const [isSaving, setIsSaving] = useState(false);
   const [showColorPicker, setShowColorPicker] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const { data: serverConfig } = useServerConfigQuery();
 
   // Type assertion for D&D 5e character data
   const data = character.data as any;
@@ -342,9 +345,10 @@ export const DnD5eCharacterEditor: React.FC<DnD5eCharacterEditorProps> = ({
         setErrors({ ...errors, tokenImage: 'Please select an image file' });
         return;
       }
-      // Validate file size (5MB max for tokens)
-      if (file.size > 5 * 1024 * 1024) {
-        setErrors({ ...errors, tokenImage: 'Image must be smaller than 5MB' });
+      // Validate file size against the server's token limit
+      const tokenLimit = getUploadLimit(serverConfig, AssetType.TOKEN);
+      if (file.size > tokenLimit) {
+        setErrors({ ...errors, tokenImage: `Image must be smaller than ${formatUploadLimit(tokenLimit)}` });
         return;
       }
       setTokenImageFile(file);
@@ -435,8 +439,9 @@ export const DnD5eCharacterEditor: React.FC<DnD5eCharacterEditorProps> = ({
       let newTokenImageUrl: string | undefined = undefined;
       if (tokenImageFile) {
         try {
+          // File last: multer parses parts in order, so the server knows the
+          // asset type even if it aborts an oversize file mid-stream.
           const assetFormData = new FormData();
-          assetFormData.append('file', tokenImageFile);
           assetFormData.append('type', 'TOKEN');
           if (character.campaignId) {
             assetFormData.append('scope', 'CAMPAIGN');
@@ -445,6 +450,7 @@ export const DnD5eCharacterEditor: React.FC<DnD5eCharacterEditorProps> = ({
             assetFormData.append('scope', 'USER');
           }
           assetFormData.append('name', `${formData.characterName || 'Character'} Token`);
+          assetFormData.append('file', tokenImageFile);
 
           const uploadResponse = await api.uploadAsset(assetFormData);
           const assetId = uploadResponse.asset.id;

--- a/frontend/src/components/character-sheets/flexible/FlexibleCharacterSheetEdit.tsx
+++ b/frontend/src/components/character-sheets/flexible/FlexibleCharacterSheetEdit.tsx
@@ -15,6 +15,9 @@ import { ListEditor } from './components/sections/ListEditor';
 import { TextEditor } from './components/sections/TextEditor';
 import { TableEditor } from './components/sections/TableEditor';
 import { api } from '../../../services/api';
+import { AssetType } from '../../../types';
+import { useServerConfigQuery } from '@/hooks/queries';
+import { getUploadLimit, formatUploadLimit } from '@/utils/uploadLimits';
 
 interface FlexibleCharacterSheetEditProps {
   character: Character;
@@ -36,6 +39,7 @@ export const FlexibleCharacterSheetEdit: React.FC<FlexibleCharacterSheetEditProp
     character.tokenImageUrl
   );
   const [tokenError, setTokenError] = useState<string>('');
+  const { data: serverConfig } = useServerConfigQuery();
 
   // Handle token image upload
   const handleTokenImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -45,8 +49,9 @@ export const FlexibleCharacterSheetEdit: React.FC<FlexibleCharacterSheetEditProp
         setTokenError('Please select an image file');
         return;
       }
-      if (file.size > 5 * 1024 * 1024) {
-        setTokenError('Image must be smaller than 5MB');
+      const tokenLimit = getUploadLimit(serverConfig, AssetType.TOKEN);
+      if (file.size > tokenLimit) {
+        setTokenError(`Image must be smaller than ${formatUploadLimit(tokenLimit)}`);
         return;
       }
       setTokenImageFile(file);
@@ -67,7 +72,7 @@ export const FlexibleCharacterSheetEdit: React.FC<FlexibleCharacterSheetEditProp
       if (tokenImageFile) {
         try {
           const assetFormData = new FormData();
-          assetFormData.append('file', tokenImageFile);
+          // File last so the server can name the type if it rejects the upload
           assetFormData.append('type', 'TOKEN');
           if (character.campaignId) {
             assetFormData.append('scope', 'CAMPAIGN');
@@ -76,6 +81,7 @@ export const FlexibleCharacterSheetEdit: React.FC<FlexibleCharacterSheetEditProp
             assetFormData.append('scope', 'USER');
           }
           assetFormData.append('name', `${character.name} Token`);
+          assetFormData.append('file', tokenImageFile);
 
           const uploadResponse = await api.uploadAsset(assetFormData);
           const assetId = uploadResponse.asset.id;

--- a/frontend/src/components/character-sheets/pathfinder2e/Pathfinder2eCharacterEditor.tsx
+++ b/frontend/src/components/character-sheets/pathfinder2e/Pathfinder2eCharacterEditor.tsx
@@ -22,6 +22,9 @@ import {
 } from 'lucide-react';
 import { ProficiencyRank, calculateProficiencyBonus } from './components/ProficiencyIndicator';
 import { api } from '../../../services/api';
+import { AssetType } from '../../../types';
+import { useServerConfigQuery } from '@/hooks/queries';
+import { getUploadLimit, formatUploadLimit } from '@/utils/uploadLimits';
 
 interface Pathfinder2eCharacterEditorProps {
   character: any;
@@ -90,6 +93,7 @@ export const Pathfinder2eCharacterEditor: React.FC<Pathfinder2eCharacterEditorPr
   const [isSaving, setIsSaving] = useState(false);
   const [showColorPicker, setShowColorPicker] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const { data: serverConfig } = useServerConfigQuery();
 
   const data = character.data as any;
 
@@ -454,8 +458,9 @@ export const Pathfinder2eCharacterEditor: React.FC<Pathfinder2eCharacterEditorPr
         setErrors({ ...errors, tokenImage: 'Please select an image file' });
         return;
       }
-      if (file.size > 5 * 1024 * 1024) {
-        setErrors({ ...errors, tokenImage: 'Image must be smaller than 5MB' });
+      const tokenLimit = getUploadLimit(serverConfig, AssetType.TOKEN);
+      if (file.size > tokenLimit) {
+        setErrors({ ...errors, tokenImage: `Image must be smaller than ${formatUploadLimit(tokenLimit)}` });
         return;
       }
       setTokenImageFile(file);
@@ -509,7 +514,7 @@ export const Pathfinder2eCharacterEditor: React.FC<Pathfinder2eCharacterEditorPr
       if (tokenImageFile) {
         try {
           const assetFormData = new FormData();
-          assetFormData.append('file', tokenImageFile);
+          // File last so the server can name the type if it rejects the upload
           assetFormData.append('type', 'TOKEN');
           if (character.campaignId) {
             assetFormData.append('scope', 'CAMPAIGN');
@@ -518,6 +523,7 @@ export const Pathfinder2eCharacterEditor: React.FC<Pathfinder2eCharacterEditorPr
             assetFormData.append('scope', 'USER');
           }
           assetFormData.append('name', `${formData.characterName || 'Character'} Token`);
+          assetFormData.append('file', tokenImageFile);
 
           const uploadResponse = await api.uploadAsset(assetFormData);
           const assetId = uploadResponse.asset.id;

--- a/frontend/src/hooks/queries/index.ts
+++ b/frontend/src/hooks/queries/index.ts
@@ -26,7 +26,23 @@ export const queryKeys = {
   characters: ['characters'] as const,
   pendingInvitations: ['invitations', 'pending'] as const,
   assets: (params: AssetListParams) => ['assets', params] as const,
+  serverConfig: ['server-config'] as const,
 };
+
+/**
+ * Server-enforced upload limits. Changes only when the server restarts with new
+ * MAX_*_SIZE_MB values, so it is cached for the session; callers fall back to
+ * DEFAULT_UPLOAD_LIMITS (utils/uploadLimits.ts) while it loads or if the
+ * endpoint is unavailable (e.g. an older backend).
+ */
+export function useServerConfigQuery() {
+  return useQuery({
+    queryKey: queryKeys.serverConfig,
+    queryFn: () => api.getServerConfig(),
+    staleTime: Infinity,
+    retry: 1,
+  });
+}
 
 export function useCampaignsQuery() {
   return useQuery({

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -87,6 +87,15 @@ function formatBytes(bytes: number): string {
   return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`;
 }
 
+/**
+ * Body size a reverse proxy must accept: the largest upload limit plus a few MB
+ * of multipart overhead (mirrors UPLOAD_OVERHEAD_BYTES in the backend).
+ */
+function requiredProxyBodyMB(uploadLimits: Record<string, number>): number {
+  const largest = Math.max(...Object.values(uploadLimits));
+  return Math.ceil((largest + 5 * 1024 * 1024) / (1024 * 1024));
+}
+
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return '\u2014';
   return new Date(dateStr).toLocaleDateString(undefined, {
@@ -1901,6 +1910,17 @@ export default function AdminPage() {
                       ))}
                     </tbody>
                   </table>
+                  <p className="text-xs text-warm-gray/70 mt-3">
+                    Your reverse proxy must allow request bodies of at least{' '}
+                    <strong>{requiredProxyBodyMB(serverConfig.uploadLimits)} MB</strong>, or larger
+                    uploads fail with HTTP 413 before reaching the API. For the bundled Nginx, set{' '}
+                    <code className="font-mono bg-warm-gray/10 px-1 rounded">
+                      NGINX_MAX_BODY_SIZE={requiredProxyBodyMB(serverConfig.uploadLimits)}M
+                    </code>{' '}
+                    in your <code className="font-mono bg-warm-gray/10 px-1 rounded">.env</code> and
+                    restart. Cloudflare-proxied setups (including Tunnels) also cap request bodies at
+                    100 MB on Free/Pro plans.
+                  </p>
                 </div>
               ) : (
                 <p className="text-xs text-warm-gray">Could not load upload limits.</p>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -11,7 +11,10 @@ import { profileService } from '@/services/profile.service';
 import { api } from '@/services/api';
 import MFASection from '@/components/profile/MFASection';
 import ThemePicker, { DEFAULT_CUSTOM_COLORS, type ThemePickerColors } from '@/components/appearance/ThemePicker';
+import { AssetType } from '@/types';
 import type { UserPreferences } from '@/types';
+import { useServerConfigQuery } from '@/hooks/queries';
+import { getUploadLimit, formatUploadLimit } from '@/utils/uploadLimits';
 import {
   Upload,
   Loader2,
@@ -281,6 +284,7 @@ function SaveBar({
 
 export default function ProfilePage() {
   const { user, logout, refreshUser, changePassword } = useAuth();
+  const { data: serverConfig } = useServerConfigQuery();
   const { appearance: systemAppearance, applyUserPreferences } = useTheme();
   const navigate = useNavigate();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -400,8 +404,10 @@ export default function ProfilePage() {
       setAvatarError('Please select an image file (JPEG, PNG, or WebP)');
       return;
     }
+    // Generous bound on the source image — it is cropped and re-encoded below,
+    // and the result is checked against the server's AVATAR limit before upload.
     if (file.size > 10 * 1024 * 1024) {
-      setAvatarError('File must be smaller than 10MB');
+      setAvatarError('Image must be smaller than 10MB');
       return;
     }
     setAvatarError('');
@@ -416,6 +422,17 @@ export default function ProfilePage() {
 
   const handleCropConfirm = async (blob: Blob) => {
     setCropSrc(null);
+
+    // The server enforces MAX_AVATAR_SIZE_MB — catch it here so the user gets a
+    // clear message instead of a rejected upload.
+    const avatarLimit = getUploadLimit(serverConfig, AssetType.AVATAR);
+    if (blob.size > avatarLimit) {
+      setAvatarError(
+        `Cropped avatar is ${formatUploadLimit(blob.size)}, above the ${formatUploadLimit(avatarLimit)} limit. Try a smaller crop or a lower-resolution image.`
+      );
+      return;
+    }
+
     setAvatarUploading(true);
     try {
       const file = new File([blob], 'avatar.jpg', { type: 'image/jpeg' });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -42,6 +42,7 @@ import type {
   AdminBackup,
   AppearanceSettings,
   UserPreferences,
+  ServerConfig,
 } from '@/types';
 
 // ============================================
@@ -159,6 +160,15 @@ class ApiClient {
 
   async getAppearance(): Promise<AppearanceSettings> {
     const response = await this.client.get<AppearanceSettings>('/api/auth/appearance');
+    return response.data;
+  }
+
+  /**
+   * Server-enforced upload limits (from the MAX_*_SIZE_MB environment variables).
+   * Fetched at runtime so limit changes don't require rebuilding the SPA.
+   */
+  async getServerConfig(): Promise<ServerConfig> {
+    const response = await this.client.get<ServerConfig>('/api/config');
     return response.data;
   }
 
@@ -684,7 +694,7 @@ class ApiClient {
     return response.data;
   }
 
-  async seedSrdCreatures(campaignId: string): Promise<{ message: string; fetched: number; created: number; skipped: number; alreadyExisted: number }> {
+  async seedSrdCreatures(campaignId: string): Promise<{ message: string; fetched: number; created: number; updated: number; skipped: number; alreadyExisted: number }> {
     const response = await this.client.post(`/api/campaigns/${campaignId}/creatures/seed`);
     return response.data;
   }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -89,6 +89,13 @@ export type TokenDisplayMode = 'pog' | 'top-down' | 'full-art';
 export interface NpcStatBlock {
   /** Armor Class / Defense rating */
   ac: number;
+  /**
+   * Maximum hit points. Optional: stat blocks saved before HP was tracked have
+   * none, and callers fall back to a default (see CreatureLibrary placement).
+   */
+  hpMax?: number;
+  /** Hit dice expression, e.g. "7d8+14" (informational) */
+  hitDice?: string;
   /** Speed (e.g. "30 ft." or "30 ft., fly 60 ft.") */
   speed: string;
   /** Ability scores */
@@ -282,6 +289,23 @@ export interface AdminActivityData {
   recentSessions: AdminActivitySession[];
   onlineUsers: AdminOnlineUser[];
   recentLogs: AdminSystemLog[];
+}
+
+// ============================================
+// Public Server Config
+// ============================================
+
+/** Upload limits in bytes, keyed by asset type — served by GET /api/config. */
+export interface ServerUploadLimits {
+  MAP: number;
+  TOKEN: number;
+  AUDIO: number;
+  AVATAR: number;
+}
+
+export interface ServerConfig {
+  uploadLimits: ServerUploadLimits;
+  maxUploadBytes: number;
 }
 
 // ============================================

--- a/frontend/src/utils/uploadLimits.ts
+++ b/frontend/src/utils/uploadLimits.ts
@@ -1,0 +1,44 @@
+// ============================================
+// Upload size limits
+//
+// The server is authoritative: limits come from the MAX_*_SIZE_MB environment
+// variables and are served by GET /api/config (see useServerConfigQuery).
+// The constants below are only a fallback for when that response is not
+// available yet — first paint, offline, or a backend older than the endpoint.
+// They mirror the documented defaults in .env.example.
+// ============================================
+
+import { AssetType } from '@/types';
+import type { ServerConfig, ServerUploadLimits } from '@/types';
+
+const MB = 1024 * 1024;
+
+/** Fallback limits in bytes. DOCUMENT/OTHER are not modelled server-side. */
+export const DEFAULT_UPLOAD_LIMITS: Record<AssetType, number> = {
+  [AssetType.MAP]: 50 * MB,
+  [AssetType.TOKEN]: 5 * MB,
+  [AssetType.AUDIO]: 20 * MB,
+  [AssetType.AVATAR]: 2 * MB,
+  [AssetType.DOCUMENT]: 10 * MB,
+  [AssetType.OTHER]: 10 * MB,
+};
+
+/**
+ * Resolve the limit (in bytes) for an asset type, preferring the server's
+ * configuration and falling back to DEFAULT_UPLOAD_LIMITS.
+ */
+export function getUploadLimit(
+  serverConfig: ServerConfig | undefined,
+  type: AssetType
+): number {
+  const serverLimit = serverConfig?.uploadLimits?.[type as keyof ServerUploadLimits];
+  return typeof serverLimit === 'number' && serverLimit > 0
+    ? serverLimit
+    : DEFAULT_UPLOAD_LIMITS[type];
+}
+
+/** Human-friendly limit, e.g. "20 MB" — whole numbers stay whole. */
+export function formatUploadLimit(bytes: number): string {
+  const mb = bytes / MB;
+  return `${Number.isInteger(mb) ? mb : mb.toFixed(1)} MB`;
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,5 +1,8 @@
 # CozyVTT Nginx Reverse Proxy
-# Mounted as /etc/nginx/conf.d/default.conf in the nginx container.
+# Mounted as /etc/nginx/templates/default.conf.template in the nginx container.
+# The image's entrypoint substitutes ${NGINX_MAX_BODY_SIZE} (and nothing else —
+# see NGINX_ENVSUBST_FILTER in docker-compose.yml) and writes the result to
+# /etc/nginx/conf.d/default.conf at startup.
 #
 # SSL / HTTPS:
 #   1. Place certs in nginx/certs/ (server.crt + server.key)
@@ -15,8 +18,12 @@
 #
 # Let's Encrypt: use certbot --webroot with the challenge block below.
 
-# Upload size limit — must be >= the largest MAX_*_SIZE_MB in .env
-client_max_body_size 55M;
+# Upload size limit — must be >= the largest MAX_*_SIZE_MB in .env (plus a few MB
+# of multipart overhead). Set NGINX_MAX_BODY_SIZE in .env; docker-compose mounts
+# this file as an Nginx template and substitutes the value at container start.
+# If you run this file directly as a plain config (no template processing),
+# replace ${NGINX_MAX_BODY_SIZE} with a literal size such as 55M.
+client_max_body_size ${NGINX_MAX_BODY_SIZE};
 
 # Determine the real protocol:
 #   - If an upstream proxy set X-Forwarded-Proto (e.g. Cloudflare sends "https"),
@@ -116,7 +123,7 @@ server {
 #     ssl_ciphers         HIGH:!aNULL:!MD5;
 #     ssl_prefer_server_ciphers on;
 #
-#     client_max_body_size 55M;
+#     client_max_body_size ${NGINX_MAX_BODY_SIZE};
 #
 #     # Backup restore — needs a large body limit and long timeout
 #     location /api/admin/backups/restore {


### PR DESCRIPTION
Two settings that looked configurable but were not.

Upload limits — MAX_MAP_SIZE_MB, MAX_TOKEN_SIZE_MB, MAX_AUDIO_SIZE_MB and MAX_AVATAR_SIZE_MB were documented, injected by docker-compose and shown in the admin panel, but no code ever read them: every limit was a hardcoded constant duplicated across four files, and the generic multer instance capped every upload at 25 MB regardless. Limits now resolve from the environment at startup, the SPA reads them at runtime from the new public GET /api/config (so changing one needs a restart, not an image rebuild), and the bundled Nginx takes client_max_body_size from the new NGINX_MAX_BODY_SIZE. The backend logs its effective limits and warns when a proxy body cap is too small, including Cloudflare's 100 MB cap on proxied requests, which Tunnels inherit.

Creature HP — hit points were not part of a creature stat block at all. The HP Max field never reached the save payload and reloaded from a constant, so it always showed 10; placement hardcoded 10 HP; and the SRD importer fetched Open5e's hit_points and hit_dice then discarded them. hpMax/hitDice are now stored, loaded back into the form, used when placing a token, and displayed in stat blocks. Re-running Seed SRD backfills hit points onto SRD creatures already in a library, adding only the missing keys and never touching custom creatures.

Also fixed: "NaNMB" in oversize-upload errors, drag-and-drop validating against the asset type selected when the dialog opened, the 10 MB client / 2 MB server avatar mismatch, and five token-image uploaders that hardcoded 5 MB.

No database migration. All new fields and environment variables are optional and default to existing behaviour.