### PR TITLE
Release 1.1.2: readable text on every theme, invite users by email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@
 .env.production
 .env.*.local
 *.env.local
+# Any other suffix too (.env.test, .env.staging, .env.dev, …) — these hold real
+# credentials just as often as .env does. The committed templates are re-included
+# below.
+.env.*
+!.env.example
 
 # ---- Dependencies -----------------------------------------------------------
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Invite users by email.** With SMTP configured, admins can add someone from **Admin → Users → Invite User** by entering just an email address and role. The person receives a link, chooses their own password, and signs in — no password is ever generated, shown to the admin, or sent by email. Links are valid for 7 days, and a **Invite** button on any user who has never signed in sends a fresh one (invalidating the previous link). Instances without SMTP keep using Create User exactly as before
+
+### Fixed
+
+- **Admin-issued temporary passwords now stop working once used.** Accounts created or reset by an admin were flagged as needing a password change, and the login response even said so — but nothing acted on it, so the temporary password the admin had just seen kept working indefinitely and the user was never prompted. The flag is now enforced on the server: until the password is replaced, every API call except changing it is refused, WebSocket connections are declined, and the app sends the user straight to a change-password screen
+- Resetting a user's password from the admin panel now signs out that user's existing sessions, instead of leaving them browsing on a session created with the old password
+
+### Changed
+
+- The temporary password from **Create User** is no longer displayed to the admin when the welcome email was delivered successfully — it is shown only when there is no other way to hand it over (no SMTP, or the send failed)
+- Password requirement checklists are now defined once and shared by every screen that sets a password, so they cannot drift from what the server enforces
+
 ### Documentation
 
 - **Fixed the external-reverse-proxy instructions, which described a setup that cannot work.** Removing the bundled `nginx` service leaves *nothing* publishing a port — the backend and frontend are `expose`-only — so the old "Option A" sent people's proxies at a closed port. The API then either failed outright (502 during setup) or, when a proxy pointed only at the frontend, returned the web page itself for every `/api` call, which made a brand-new install show the login page instead of the setup wizard. Option A now covers publishing both services on `127.0.0.1`, why the loopback prefix matters (and that Docker's published ports bypass UFW), and the routing every proxy must do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Documentation
+
+- **Fixed the external-reverse-proxy instructions, which described a setup that cannot work.** Removing the bundled `nginx` service leaves *nothing* publishing a port — the backend and frontend are `expose`-only — so the old "Option A" sent people's proxies at a closed port. The API then either failed outright (502 during setup) or, when a proxy pointed only at the frontend, returned the web page itself for every `/api` call, which made a brand-new install show the login page instead of the setup wizard. Option A now covers publishing both services on `127.0.0.1`, why the loopback prefix matters (and that Docker's published ports bypass UFW), and the routing every proxy must do
+- **New Cloudflare Tunnel section** covering all three working setups — keeping the bundled nginx (one ingress rule), running `cloudflared` as a container on CozyVTT's network, and running it on the host with path rules — including that ingress rules match in order so the catch-all must be last, and that `localhost` inside a container means the container itself
+- **New troubleshooting section**: fresh install showing the login page instead of the setup wizard, setup failing with 502, live features not updating, `git pull` blocked by local changes, and large uploads failing — each with the one-command check that identifies it
+- **New `docker-compose.override.example.yml`** and docs for keeping personal deployment tweaks in `docker-compose.override.yml`, which Compose merges automatically and git ignores, so `git pull` stops conflicting with local edits. Also documents the `git stash` workflow for anyone who edits `docker-compose.yml` directly
+- Corrected the health-check instructions — `/health` is served by the backend and is not forwarded by the bundled Nginx, so `curl http://localhost/health` never worked; the docs now use `docker compose exec`
+- `docker-compose.yml` header comments now list everything required to run without the bundled nginx (comments only — no configuration changes)
+
+---
+
 ## [1.1.1] — 2026-08-17
 
 A bug-fix release for two settings that looked configurable but weren't: upload size limits set in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [Unreleased]
+## [1.1.2] — 2026-08-21
+
+A readability and account-management release: text is legible on every theme, admins can invite users
+by email instead of handing out passwords, and the external-reverse-proxy documentation now describes
+a setup that actually works. No breaking changes and no database migration — update and restart.
 
 ### Added
 
-- **Invite users by email.** With SMTP configured, admins can add someone from **Admin → Users → Invite User** by entering just an email address and role. The person receives a link, chooses their own password, and signs in — no password is ever generated, shown to the admin, or sent by email. Links are valid for 7 days, and a **Invite** button on any user who has never signed in sends a fresh one (invalidating the previous link). Instances without SMTP keep using Create User exactly as before
+- **Invite users by email.** With SMTP configured, admins can add someone from **Admin → Users → Invite User** by entering just an email address and role. The person receives a link, chooses their own password, and signs in — no password is ever generated, shown to the admin, or sent by email. Links are valid for 7 days, and an **Invite** button on any user who has never signed in sends a fresh one (invalidating the previous link). Instances without SMTP keep using Create User exactly as before
 
 ### Fixed
 
+- **Text is now readable on every theme.** All 16 built-in themes failed the WCAG AA contrast minimum somewhere, despite the codebase claiming otherwise: muted text — the most common text color in the app — sat between 3.3:1 and 4.4:1 on 13 themes, accent-colored text dropped to 1.84:1 on Northern Frost, and headings fell to 2.6:1 on Shadow Realm. Measured across every theme, text role and surface, **141 unreadable combinations are now zero**, with the worst pairing anywhere improved from 1.71:1 to 4.50:1
+- **Screens now follow your theme.** Error, success and warning panels, status badges, NPC stat blocks and various inline messages were built from fixed colors, so on the dark themes they appeared as pale pink or washed-out boxes with near-invisible text. Roughly 850 hardcoded colors across 50 files now use theme-aware tokens
+- Stat blocks in the creature library and NPC editor used dark text with no background of their own, making them nearly unreadable on all four dark themes
+- The Pathfinder and Call of Cthulhu stat block accents never rendered at all — they were built from dynamic class names the styling system cannot generate
+- Faint labels and icons on character sheets (as low as 1.4:1) and unreadable hint text on the DM wall, light and fog control panels
 - **Admin-issued temporary passwords now stop working once used.** Accounts created or reset by an admin were flagged as needing a password change, and the login response even said so — but nothing acted on it, so the temporary password the admin had just seen kept working indefinitely and the user was never prompted. The flag is now enforced on the server: until the password is replaced, every API call except changing it is refused, WebSocket connections are declined, and the app sends the user straight to a change-password screen
 - Resetting a user's password from the admin panel now signs out that user's existing sessions, instead of leaving them browsing on a session created with the old password
 
 ### Changed
 
+- Custom theme colors are now checked for readability: the theme picker shows the contrast ratio of each key text/background pair and flags anything below the 4.5:1 minimum, and derived text shades are adjusted automatically instead of being computed by fixed lightening steps that could produce unreadable results
 - The temporary password from **Create User** is no longer displayed to the admin when the welcome email was delivered successfully — it is shown only when there is no other way to hand it over (no SMTP, or the send failed)
 - Password requirement checklists are now defined once and shared by every screen that sets a password, so they cannot drift from what the server enforces
 
@@ -30,6 +40,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **New `docker-compose.override.example.yml`** and docs for keeping personal deployment tweaks in `docker-compose.override.yml`, which Compose merges automatically and git ignores, so `git pull` stops conflicting with local edits. Also documents the `git stash` workflow for anyone who edits `docker-compose.yml` directly
 - Corrected the health-check instructions — `/health` is served by the backend and is not forwarded by the bundled Nginx, so `curl http://localhost/health` never worked; the docs now use `docker compose exec`
 - `docker-compose.yml` header comments now list everything required to run without the bundled nginx (comments only — no configuration changes)
+
+### Upgrading from 1.1.1
+
+```bash
+git pull
+docker compose up -d --build
+```
+
+No database migration, no configuration changes. Verified by upgrading a 1.1.1 instance in place:
+existing accounts sign in with their original passwords and are **not** forced to reset, campaigns,
+characters and uploaded files are untouched, and saved theme choices — including custom colors — carry
+over exactly.
+
+Two changes are visible immediately and are intentional:
+
+- Muted and accent-colored text shifts slightly (darker on light themes, lighter on dark ones) — that
+  text was below the readable minimum on most themes
+- Error, success and warning panels now tint with your theme instead of always being pale pink or green
+
+If your instance has SMTP configured, **Admin → Users** gains an **Invite User** button; if it doesn't,
+Create User behaves exactly as before.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ All runtime configuration is managed through the Admin dashboard after setup:
 
 | Tab | Setting | Description |
 |-----|---------|-------------|
+| Users | Invite User | Email someone a link to join and choose their own password (needs SMTP; link valid 7 days) |
+| Users | Create User | Generate a temporary password to hand over yourself — for instances without email |
 | Settings | Instance Name | Displayed in the browser title and emails |
 | Settings | Allow Registration | Whether new users can self-register |
 | Settings | Require Admin Approval | New registrations must be approved before login |
@@ -187,6 +189,9 @@ All runtime configuration is managed through the Admin dashboard after setup:
 | Appearance | Default Theme | Theme shown on the login page and used for new users (each user can override from their profile) |
 | Appearance | Default Font | Default font family applied alongside the default theme |
 | Appearance | Custom Branding | Upload custom logo, mascot icon, and favicon (always instance-wide) |
+
+However an account is added, its first sign-in ends with the person choosing their own password — an
+admin-issued temporary password cannot be used for anything else.
 
 ### Default Upload Limits
 

--- a/backend/docs/API_DOCUMENTATION.yaml
+++ b/backend/docs/API_DOCUMENTATION.yaml
@@ -40,7 +40,7 @@ info:
     Real-time campaign features (token movement, dice, chat, initiative, etc.) use Socket.io.
     See the WebSocket section at the bottom of this document for the full event reference.
 
-  version: 1.1.1
+  version: 1.1.2
   contact:
     name: CozyVTT
     url: https://cozyvtt.com

--- a/backend/docs/API_DOCUMENTATION.yaml
+++ b/backend/docs/API_DOCUMENTATION.yaml
@@ -28,6 +28,14 @@ info:
 
     Rate-limited responses return HTTP 429 with `RateLimit-*` standard headers.
 
+    ## Forced password changes
+    Accounts an admin created, or whose password an admin reset, are flagged
+    `mustChangePassword`. Until a new password is set, every endpoint except
+    `POST /api/auth/change-password`, `POST /api/auth/logout`, `GET /api/auth/me`,
+    `GET /api/auth/ping`, `GET /api/auth/appearance` and `GET /api/config` returns
+    HTTP 403 with `code: PASSWORD_CHANGE_REQUIRED`. WebSocket connections are refused
+    on the same basis. Clients should route on `code` rather than the message.
+
     ## Real-time Events
     Real-time campaign features (token movement, dice, chat, initiative, etc.) use Socket.io.
     See the WebSocket section at the bottom of this document for the full event reference.
@@ -4590,7 +4598,15 @@ paths:
     post:
       tags: [Admin]
       summary: Create a new user
-      description: Creates a user with a generated temporary password. The user must change their password on first login (`mustChangePassword` is set to true).
+      description: |
+        Creates a user with a generated temporary password. The account is flagged
+        `mustChangePassword`, so that password can only be used to set a real one — every
+        other endpoint returns 403 `PASSWORD_CHANGE_REQUIRED` until it is replaced.
+
+        When SMTP is configured the credentials are emailed and `temporaryPassword` is
+        **withheld** from the response; it is returned only when the email could not be
+        sent, so the admin never holds a working credential unnecessarily. To create an
+        account without any password at all, use `/api/admin/users/invite`.
       operationId: adminCreateUser
       security:
         - cookieAuth: []
@@ -4624,9 +4640,14 @@ paths:
                     type: string
                   user:
                     $ref: '#/components/schemas/User'
+                  emailSent:
+                    type: boolean
+                    description: Whether the welcome email with the credentials was delivered
                   temporaryPassword:
                     type: string
-                    description: One-time temporary password — store securely and share with user
+                    description: >-
+                      One-time temporary password. Present ONLY when emailSent is false —
+                      share it securely; it is not retrievable afterwards.
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -4635,6 +4656,108 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '409':
           description: Email already in use
+
+  /api/admin/users/invite:
+    post:
+      tags: [Admin]
+      summary: Invite a user by email
+      description: |
+        Creates an account with **no usable password** and emails the new user a link to
+        choose one. The link expires in 7 days and is the only way into the account, so
+        no credential is ever returned or shown to the inviting admin.
+
+        Requires SMTP. If the invitation cannot be delivered the account is rolled back
+        rather than left unreachable.
+
+        The recipient completes setup at `/accept-invite?token=…`, which submits to
+        `POST /api/auth/reset-password` — invitations and password resets share the same
+        token machinery.
+      operationId: adminInviteUser
+      security:
+        - cookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email]
+              properties:
+                email:
+                  type: string
+                  format: email
+                displayName:
+                  type: string
+                  maxLength: 50
+                platformRole:
+                  type: string
+                  enum: [USER, ADMIN]
+                  default: USER
+      responses:
+        '201':
+          description: Invitation sent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  user:
+                    $ref: '#/components/schemas/User'
+                  expiresInDays:
+                    type: integer
+                    example: 7
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          description: Email already in use
+        '502':
+          description: The invitation email could not be delivered; no account was created
+        '503':
+          description: SMTP is not configured on this instance
+
+  /api/admin/users/{id}/resend-invite:
+    post:
+      tags: [Admin]
+      summary: Resend an invitation
+      description: |
+        Issues a fresh invitation link and invalidates any outstanding one. Useful when the
+        original expired or never arrived. Requires SMTP.
+      operationId: adminResendInvite
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Invitation resent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  expiresInDays:
+                    type: integer
+                    example: 7
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '503':
+          description: SMTP is not configured on this instance
 
   /api/admin/users/{id}/approve:
     post:
@@ -6306,6 +6429,21 @@ components:
           example:
             error: Forbidden
             message: You do not have permission to perform this action.
+
+    PasswordChangeRequired:
+      description: >-
+        Forbidden - The account must set a new password before it can do anything else
+        (admin-created account, or an admin reset its password). Returned by every
+        endpoint except change-password, logout, /auth/me, /auth/ping, /auth/appearance
+        and /api/config. Route on `code`, not the message.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            error: Password Change Required
+            code: PASSWORD_CHANGE_REQUIRED
+            message: You must set a new password before continuing.
 
     NotFound:
       description: Not Found - Resource does not exist or you cannot see it.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cozyvtt-backend",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cozyvtt-backend",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "5.8",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozyvtt-backend",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "CozyVTT Backend - Self-hosted Virtual Tabletop",
   "main": "dist/server.js",
   "scripts": {

--- a/backend/src/middleware/passwordChange.test.ts
+++ b/backend/src/middleware/passwordChange.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Forced Password Change Middleware — Unit Tests
+ *
+ * Accounts flagged `mustChangePassword` may only reach the endpoints needed to
+ * replace that password. Everything else must be refused, or an admin-issued
+ * temporary password keeps working indefinitely.
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { requirePasswordChanged, PASSWORD_CHANGE_REQUIRED } from './passwordChange';
+
+// The middleware falls back to a database read when the session predates the
+// flag; that path is exercised in the "legacy session" tests below.
+const mockFindUnique = jest.fn();
+jest.mock('../config/database', () => ({
+  prisma: {
+    user: {
+      findUnique: (...args: unknown[]) => mockFindUnique(...args),
+    },
+  },
+}));
+
+function mockReq(path: string, sessionOverrides: Record<string, any> = {}): Request {
+  return {
+    path,
+    session: {
+      ...sessionOverrides,
+      id: 'test-session-id',
+      cookie: {} as any,
+      regenerate: jest.fn(),
+      destroy: jest.fn(),
+      reload: jest.fn(),
+      resetMaxAge: jest.fn(),
+      save: jest.fn(),
+      touch: jest.fn(),
+    } as any,
+  } as unknown as Request;
+}
+
+function mockRes(): { status: jest.Mock; json: jest.Mock; res: Response } {
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  return { status, json, res: { status, json } as unknown as Response };
+}
+
+const mockNext: NextFunction = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ============================================
+// Pass-through cases
+// ============================================
+
+describe('requirePasswordChanged — allows through', () => {
+  it('unauthenticated requests (other guards handle those)', async () => {
+    const req = mockReq('/campaigns');
+    const { res } = mockRes();
+
+    await requirePasswordChanged(req, res, mockNext);
+
+    expect(mockNext).toHaveBeenCalledTimes(1);
+    expect(mockFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('sessions with no pending password change', async () => {
+    const req = mockReq('/campaigns', { userId: 'user-1', mustChangePassword: false });
+    const { res, status } = mockRes();
+
+    await requirePasswordChanged(req, res, mockNext);
+
+    expect(mockNext).toHaveBeenCalledTimes(1);
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    '/auth/change-password',
+    '/auth/logout',
+    '/auth/me',
+    '/auth/ping',
+    '/auth/appearance',
+    '/config',
+  ])('the allowlisted path %s even while pending', async (path) => {
+    const req = mockReq(path, { userId: 'user-1', mustChangePassword: true });
+    const { res, status } = mockRes();
+
+    await requirePasswordChanged(req, res, mockNext);
+
+    expect(mockNext).toHaveBeenCalledTimes(1);
+    expect(status).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================
+// Blocking
+// ============================================
+
+describe('requirePasswordChanged — blocks', () => {
+  it('any other route while a password change is pending', async () => {
+    const req = mockReq('/campaigns', { userId: 'user-1', mustChangePassword: true });
+    const { res, status, json } = mockRes();
+
+    await requirePasswordChanged(req, res, mockNext);
+
+    expect(mockNext).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(403);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: PASSWORD_CHANGE_REQUIRED })
+    );
+  });
+
+  it('a near-miss path that only starts like an allowlisted one', async () => {
+    const req = mockReq('/auth/me/campaigns', { userId: 'user-1', mustChangePassword: true });
+    const { res, status } = mockRes();
+
+    await requirePasswordChanged(req, res, mockNext);
+
+    expect(mockNext).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(403);
+  });
+});
+
+// ============================================
+// Sessions created before the flag existed
+// ============================================
+
+describe('requirePasswordChanged — legacy sessions', () => {
+  it('reads the database once and caches the answer in the session', async () => {
+    mockFindUnique.mockResolvedValue({ mustChangePassword: true });
+    const req = mockReq('/campaigns', { userId: 'user-1' }); // no flag in session
+    const { res, status } = mockRes();
+
+    await requirePasswordChanged(req, res, mockNext);
+
+    expect(mockFindUnique).toHaveBeenCalledTimes(1);
+    expect(status).toHaveBeenCalledWith(403);
+    // Cached, so the next request costs nothing
+    expect(req.session.mustChangePassword).toBe(true);
+  });
+
+  it('lets a legacy session through when the account is fine', async () => {
+    mockFindUnique.mockResolvedValue({ mustChangePassword: false });
+    const req = mockReq('/campaigns', { userId: 'user-1' });
+    const { res } = mockRes();
+
+    await requirePasswordChanged(req, res, mockNext);
+
+    expect(mockNext).toHaveBeenCalledTimes(1);
+    expect(req.session.mustChangePassword).toBe(false);
+  });
+
+  it('fails open on a database error rather than locking everyone out', async () => {
+    mockFindUnique.mockRejectedValue(new Error('connection refused'));
+    const req = mockReq('/campaigns', { userId: 'user-1' });
+    const { res, status } = mockRes();
+
+    await requirePasswordChanged(req, res, mockNext);
+
+    expect(mockNext).toHaveBeenCalledTimes(1);
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it('does not block when the session points at a deleted user', async () => {
+    mockFindUnique.mockResolvedValue(null);
+    const req = mockReq('/campaigns', { userId: 'ghost' });
+    const { res } = mockRes();
+
+    await requirePasswordChanged(req, res, mockNext);
+
+    expect(mockNext).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/middleware/passwordChange.ts
+++ b/backend/src/middleware/passwordChange.ts
@@ -1,0 +1,87 @@
+import { Request, Response, NextFunction } from 'express';
+import { prisma } from '../config/database';
+import logger from '../utils/logger';
+
+/**
+ * Forced Password Change Middleware
+ *
+ * Accounts an admin created — and accounts whose password an admin reset — are
+ * flagged with `mustChangePassword`. Until that password is replaced, the
+ * session may do exactly one thing: replace it. Without this gate, the
+ * temporary password the admin generated (and saw) keeps working indefinitely.
+ *
+ * Mounted on /api after the session middleware. Unauthenticated requests pass
+ * straight through — the regular auth guards handle those.
+ */
+
+/** Machine-readable code so the frontend can redirect instead of guessing. */
+export const PASSWORD_CHANGE_REQUIRED = 'PASSWORD_CHANGE_REQUIRED';
+
+/**
+ * Paths that stay reachable while a password change is pending.
+ * Relative to the /api mount point.
+ */
+const ALLOWED_PATHS = new Set([
+  '/auth/change-password', // the one thing a gated session may do
+  '/auth/logout',
+  '/auth/me',
+  '/auth/ping',
+  '/auth/appearance',
+  '/config',
+]);
+
+/**
+ * Resolve the flag for the current session.
+ *
+ * The session copy is authoritative and costs nothing. Sessions created before
+ * this field existed hold `undefined`, so fall back to a single database read
+ * and cache the answer — existing logins keep working across the upgrade rather
+ * than being force-logged-out.
+ */
+async function isPasswordChangePending(req: Request): Promise<boolean> {
+  if (typeof req.session.mustChangePassword === 'boolean') {
+    return req.session.mustChangePassword;
+  }
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: req.session.userId },
+      select: { mustChangePassword: true },
+    });
+
+    // No user behind this session — let the auth guards deal with it
+    if (!user) return false;
+
+    req.session.mustChangePassword = user.mustChangePassword;
+    return user.mustChangePassword;
+  } catch (error) {
+    // Never lock everyone out of the app over a transient database error
+    logger.error('Error checking password-change status', { err: error });
+    return false;
+  }
+}
+
+export async function requirePasswordChanged(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  if (!req.session?.userId) {
+    return next();
+  }
+
+  if (ALLOWED_PATHS.has(req.path)) {
+    return next();
+  }
+
+  if (await isPasswordChangePending(req)) {
+    res.status(403).json({
+      error: 'Password Change Required',
+      code: PASSWORD_CHANGE_REQUIRED,
+      message: 'You must set a new password before continuing.',
+    });
+    return;
+  }
+
+  next();
+}

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -24,7 +24,7 @@ import {
 } from '../services/systemSettings';
 import { sanitizeInput, validateEmail } from '../utils/validation';
 import { hashPassword, sanitizeUser } from '../services/auth';
-import { isSmtpConfigured, sendTestEmail, sendWelcomeEmail } from '../services/email';
+import { isSmtpConfigured, sendTestEmail, sendWelcomeEmail, sendInvitationEmail } from '../services/email';
 import { FILE_SIZE_LIMITS } from '../utils/fileUtils';
 import { extractArchiveSafely } from '../utils/archive';
 import logger from '../utils/logger';
@@ -93,6 +93,13 @@ async function writeAdminLog(
     logger.error('Failed to write system log', { err: e });
   }
 }
+
+/**
+ * How long an invitation link stays valid. Longer than the 1-hour password
+ * reset window on purpose — an invitation has to survive someone not checking
+ * email over a weekend.
+ */
+const INVITE_EXPIRY_DAYS = 7;
 
 function generateTemporaryPassword(): string {
   const bytes = crypto.randomBytes(16);
@@ -277,21 +284,202 @@ router.post('/users', async (req, res) => {
       { targetUserId: user.id, role }
     );
 
-    // Send welcome email if SMTP is configured
+    // Send the welcome email if SMTP is configured. Awaited, because whether it
+    // succeeded decides if the admin needs to see the password at all.
+    let emailSent = false;
     if (isSmtpConfigured()) {
-      sendWelcomeEmail(user.email, user.displayName, temporaryPassword).catch((err) => {
+      try {
+        await sendWelcomeEmail(user.email, user.displayName, temporaryPassword);
+        emailSent = true;
+      } catch (err) {
         logger.error(`[admin] Failed to send welcome email to ${user.email}`, { err: err });
-      });
+      }
     }
 
     return res.status(201).json({
-      message: 'User created successfully',
+      message: emailSent
+        ? `User created. Sign-in details were emailed to ${user.email}.`
+        : 'User created successfully',
       user: sanitizeUser(user),
-      temporaryPassword,
+      emailSent,
+      // Withheld once the user has it by email — no reason for the admin to
+      // hold a working credential for someone else's account
+      ...(emailSent ? {} : { temporaryPassword }),
     });
   } catch (error) {
     logger.error('Error creating user', { err: error });
     return res.status(500).json({ error: 'Internal Server Error', message: 'Failed to create user' });
+  }
+});
+
+// ============================================
+// POST /api/admin/users/invite
+// Creates an account with NO usable password and emails the new user a link to
+// choose their own. Requires SMTP — the link is the only way into the account,
+// so there is nothing to hand over manually.
+// ============================================
+
+router.post('/users/invite', async (req, res) => {
+  try {
+    if (!isSmtpConfigured()) {
+      return res.status(503).json({
+        error: 'Service Unavailable',
+        message:
+          'SMTP is not configured on this instance, so invitations cannot be emailed. Configure SMTP in your .env, or use Create User to generate a temporary password instead.',
+      });
+    }
+
+    const { email, displayName, platformRole } = req.body;
+
+    if (!email || typeof email !== 'string') {
+      return res.status(400).json({ error: 'Bad Request', message: 'Email is required' });
+    }
+    if (!validateEmail(email)) {
+      return res.status(400).json({ error: 'Bad Request', message: 'Invalid email address' });
+    }
+
+    const existing = await prisma.user.findUnique({ where: { email: email.toLowerCase() } });
+    if (existing) {
+      return res.status(409).json({ error: 'Conflict', message: 'Email is already in use' });
+    }
+
+    const role = platformRole === 'ADMIN' ? 'ADMIN' : 'USER';
+    const rawName = typeof displayName === 'string' && displayName.trim()
+      ? displayName
+      : email.split('@')[0];
+
+    // The account is created with an unusable password: a hash of random bytes
+    // that are discarded immediately. Nobody — including this admin — holds a
+    // credential for it. The invitation token is the only way in.
+    const unusablePassword = crypto.randomBytes(32).toString('hex');
+    const passwordHash = await hashPassword(unusablePassword);
+
+    const user = await prisma.user.create({
+      data: {
+        email: sanitizeInput(email).toLowerCase(),
+        displayName: sanitizeInput(rawName).slice(0, 50),
+        passwordHash,
+        platformRole: role,
+        // The invitation link sets the password, so there is nothing to force
+        // a change of afterwards
+        mustChangePassword: false,
+      },
+    });
+
+    const token = crypto.randomUUID();
+    await prisma.passwordResetToken.create({
+      data: {
+        userId: user.id,
+        token,
+        expiresAt: new Date(Date.now() + INVITE_EXPIRY_DAYS * 24 * 60 * 60 * 1000),
+      },
+    });
+
+    const inviter = await prisma.user.findUnique({
+      where: { id: req.session.userId! },
+      select: { displayName: true },
+    });
+
+    try {
+      await sendInvitationEmail(
+        user.email,
+        token,
+        user.displayName,
+        inviter?.displayName || 'An administrator',
+        INVITE_EXPIRY_DAYS
+      );
+    } catch (err) {
+      // The account exists but is unreachable without the emailed link, so roll
+      // it back rather than leaving an unusable account behind
+      await prisma.user.delete({ where: { id: user.id } }).catch(() => undefined);
+      logger.error(`[admin] Failed to send invitation to ${user.email}`, { err });
+      return res.status(502).json({
+        error: 'Email Delivery Failed',
+        message: 'The invitation could not be emailed, so the account was not created. Check your SMTP settings and try again.',
+      });
+    }
+
+    await writeAdminLog(
+      req.session.userId!,
+      `Invited user ${user.email} with role ${role}`,
+      'INFO',
+      { targetUserId: user.id, role }
+    );
+
+    return res.status(201).json({
+      message: `Invitation sent to ${user.email}`,
+      user: sanitizeUser(user),
+      expiresInDays: INVITE_EXPIRY_DAYS,
+    });
+  } catch (error) {
+    logger.error('Error inviting user', { err: error });
+    return res.status(500).json({ error: 'Internal Server Error', message: 'Failed to invite user' });
+  }
+});
+
+// ============================================
+// POST /api/admin/users/:id/resend-invite
+// Issues a fresh invitation link, invalidating any outstanding one.
+// ============================================
+
+router.post('/users/:id/resend-invite', async (req, res) => {
+  try {
+    if (!isSmtpConfigured()) {
+      return res.status(503).json({
+        error: 'Service Unavailable',
+        message: 'SMTP is not configured on this instance, so invitations cannot be emailed.',
+      });
+    }
+
+    const { id } = req.params;
+    const user = await prisma.user.findUnique({ where: { id } });
+
+    if (!user) {
+      return res.status(404).json({ error: 'Not Found', message: 'User not found' });
+    }
+
+    // Invalidate outstanding links so only the newest one works
+    await prisma.passwordResetToken.updateMany({
+      where: { userId: id, used: false },
+      data: { used: true },
+    });
+
+    const token = crypto.randomUUID();
+    await prisma.passwordResetToken.create({
+      data: {
+        userId: id,
+        token,
+        expiresAt: new Date(Date.now() + INVITE_EXPIRY_DAYS * 24 * 60 * 60 * 1000),
+      },
+    });
+
+    const inviter = await prisma.user.findUnique({
+      where: { id: req.session.userId! },
+      select: { displayName: true },
+    });
+
+    await sendInvitationEmail(
+      user.email,
+      token,
+      user.displayName,
+      inviter?.displayName || 'An administrator',
+      INVITE_EXPIRY_DAYS
+    );
+
+    await writeAdminLog(
+      req.session.userId!,
+      `Resent invitation to ${user.email}`,
+      'INFO',
+      { targetUserId: user.id }
+    );
+
+    return res.status(200).json({
+      message: `Invitation resent to ${user.email}`,
+      expiresInDays: INVITE_EXPIRY_DAYS,
+    });
+  } catch (error) {
+    logger.error('Error resending invitation', { err: error });
+    return res.status(500).json({ error: 'Internal Server Error', message: 'Failed to resend invitation' });
   }
 });
 

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -187,6 +187,8 @@ router.post('/login', authLimiter, async (req: Request, res: Response) => {
     req.session.email = user.email;
     req.session.displayName = user.displayName;
     req.session.platformRole = user.platformRole;
+    // Gates every other API call until the password is replaced
+    req.session.mustChangePassword = user.mustChangePassword;
 
     // Extend session if "Remember Me" is checked
     if (rememberMe && req.session.cookie) {
@@ -449,6 +451,9 @@ router.post('/change-password', requireAuth, async (req: Request, res: Response)
         mustChangePassword: false,
       },
     });
+
+    // Lift the gate for this session immediately (see middleware/passwordChange.ts)
+    req.session.mustChangePassword = false;
 
     return res.status(200).json({
       message: 'Password changed successfully',

--- a/backend/src/routes/mfa.ts
+++ b/backend/src/routes/mfa.ts
@@ -267,6 +267,8 @@ router.post('/verify-login', mfaLoginLimiter, async (req: AuthenticatedRequest, 
     req.session.email = user.email;
     req.session.displayName = user.displayName;
     req.session.platformRole = user.platformRole;
+    // Carried through the MFA step so the gate applies to MFA logins too
+    req.session.mustChangePassword = user.mustChangePassword;
 
     // Apply remember me if requested
     if (rememberMe) {

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -4,6 +4,7 @@ import { prisma } from '../config/database';
 import { sanitizeUser, hashPassword } from '../services/auth';
 import { validateEmail, sanitizeInput } from '../utils/validation';
 import { isSmtpConfigured, sendPasswordResetEmail } from '../services/email';
+import { destroyUserLoginSessions } from '../services/sessionStore';
 import { UpdateUserPreferencesSchema, type UserPreferences } from '../validators/userPreferences';
 import crypto from 'crypto';
 import logger from '../utils/logger';
@@ -414,11 +415,16 @@ router.post('/:id/reset-password', requireAuth, requireAdmin, async (req: Reques
       },
     });
 
+    // End any sessions the user already has open — otherwise they keep full
+    // access on the old session and the forced-change gate would only take
+    // effect at their next login
+    await destroyUserLoginSessions(id);
+
     return res.status(200).json({
       message: 'Password reset successfully',
       temporaryPassword,
       mustChangePassword: true,
-      notice: 'This temporary password will only be displayed once. The user will be required to change it on next login.',
+      notice: 'This temporary password will only be displayed once. The user will be required to change it on next login, and any active sessions have been signed out.',
     });
   } catch (error) {
     logger.error('Error resetting password', { err: error });

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -10,6 +10,7 @@ import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
 import { sessionConfig } from './config/session';
 import { requireSetupComplete } from './middleware/setup';
+import { requirePasswordChanged } from './middleware/passwordChange';
 import setupRoutes from './routes/setup';
 import authRoutes from './routes/auth';
 import campaignRoutes from './routes/campaigns';
@@ -129,6 +130,10 @@ app.get('/health', async (_req, res) => {
 
 // Apply general rate limiter to all API routes
 app.use('/api', generalApiLimiter);
+
+// Accounts flagged `mustChangePassword` (admin-created, or admin-reset) can do
+// nothing but change it until they do — see middleware/passwordChange.ts
+app.use('/api', requirePasswordChanged);
 
 // Setup wizard (accessible before setup is complete)
 app.use('/api/setup', setupRoutes);

--- a/backend/src/services/campaignExporter.ts
+++ b/backend/src/services/campaignExporter.ts
@@ -197,7 +197,7 @@ export async function exportCampaign(
   const manifest = {
     formatVersion: 1,
     exportedAt: new Date().toISOString(),
-    exportedFrom: `CozyVTT v${process.env.npm_package_version || '1.1.1'}`,
+    exportedFrom: `CozyVTT v${process.env.npm_package_version || '1.1.2'}`,
     campaignName: campaign.name,
     gameSystem: campaign.gameSystem || 'NONE',
     mapCount: mapDataArray.length,

--- a/backend/src/services/email.ts
+++ b/backend/src/services/email.ts
@@ -217,6 +217,49 @@ export async function sendWelcomeEmail(
 }
 
 /**
+ * Send an account invitation with a link to choose a password.
+ *
+ * Unlike the welcome email, no password exists yet — the account is created
+ * without a usable one, and this link is the only way in. The admin who sent
+ * the invitation never sees a credential.
+ */
+export async function sendInvitationEmail(
+  toEmail: string,
+  token: string,
+  displayName: string,
+  invitedByName: string,
+  expiryDays: number
+): Promise<void> {
+  const transporter = createTransporter();
+  const fromAddress = process.env.SMTP_FROM || process.env.SMTP_USER;
+  const appUrl = getAppUrl();
+  const instanceName = getInstanceName();
+  const inviteLink = `${appUrl}/accept-invite?token=${token}`;
+
+  const content =
+    h2(`You're invited to ${instanceName}`) +
+    p(`Hello <strong>${displayName}</strong>,`) +
+    p(`<strong>${invitedByName}</strong> has invited you to join ${instanceName}, a cozy virtual tabletop for online tabletop RPG campaigns. Click below to choose a password and finish setting up your account.`) +
+    ctaButton('Accept Invitation', inviteLink) +
+    infoBox(
+      `Or copy and paste this link into your browser:<br>` +
+      `<span style="word-break:break-all;font-family:monospace;font-size:12px;color:#5C4A2A;">${inviteLink}</span>`
+    ) +
+    warningBox(
+      `<strong>This invitation expires in ${expiryDays} days.</strong> If it expires, ask ${invitedByName} to send a new one. ` +
+      'If you were not expecting this invitation, you can safely ignore this email — no account can be used until someone sets a password with this link.'
+    );
+
+  await transporter.sendMail({
+    from: fromAddress,
+    to: toEmail,
+    subject: `${invitedByName} invited you to ${instanceName}`,
+    html: emailLayout(content, `Join ${instanceName} — set your password to get started.`),
+  });
+  logger.info('Email sent', { type: 'invitation', to: toEmail });
+}
+
+/**
  * Send a password reset email with a token link.
  * Used by both the self-service forgot-password flow and admin-initiated resets.
  */

--- a/backend/src/services/sessionStore.ts
+++ b/backend/src/services/sessionStore.ts
@@ -1,0 +1,34 @@
+import { prisma } from '../config/database';
+import logger from '../utils/logger';
+
+/**
+ * Login-session helpers.
+ *
+ * Express login sessions live in the `session` table owned by
+ * connect-pg-simple (see config/session.ts) — not in Prisma's `Session` model,
+ * which tracks in-game campaign sessions. The same raw-SQL access pattern is
+ * used by the admin activity endpoint's online-users list.
+ */
+
+/**
+ * End every login session belonging to a user.
+ *
+ * Used when an admin resets someone's password: without this the target keeps
+ * browsing on their existing session, and the forced-password-change gate would
+ * only apply the next time they log in.
+ *
+ * @returns number of sessions removed
+ */
+export async function destroyUserLoginSessions(userId: string): Promise<number> {
+  try {
+    const removed = await prisma.$executeRaw`
+      DELETE FROM session WHERE sess->>'userId' = ${userId}
+    `;
+    return removed;
+  } catch (error) {
+    // Best-effort: the password has already been changed, so a failure here
+    // must not fail the request that triggered it
+    logger.error('Failed to clear login sessions for user', { err: error, userId });
+    return 0;
+  }
+}

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -6,6 +6,11 @@ declare module 'express-session' {
     email?: string;
     displayName?: string;
     platformRole?: PlatformRole;
+    // True while the account must set a new password before doing anything else
+    // (admin-created accounts, admin password resets). Undefined on sessions
+    // created before this field existed — middleware/passwordChange.ts falls
+    // back to a database read and caches the answer here.
+    mustChangePassword?: boolean;
     // MFA flow state — set during login when user has MFA enabled
     mfaPending?: boolean;
     mfaPendingUserId?: string;

--- a/backend/src/websocket/auth.ts
+++ b/backend/src/websocket/auth.ts
@@ -30,10 +30,17 @@ export async function authenticateSocket(socket: AuthenticatedSocket): Promise<b
 
     const user = await prisma.user.findUnique({
       where: { id: session.userId },
-      select: { id: true },
+      select: { id: true, mustChangePassword: true },
     });
 
     if (!user) {
+      return false;
+    }
+
+    // Same gate the REST API applies: an account that still has to replace an
+    // admin-issued password cannot play over the socket either
+    if (user.mustChangePassword) {
+      logger.warn('WebSocket rejected: password change required', { userId: user.id });
       return false;
     }
 

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,0 +1,82 @@
+# ============================================================================
+# CozyVTT — example personal overrides
+#
+# WHAT THIS IS
+#   A place to keep YOUR deployment tweaks without editing docker-compose.yml.
+#   Docker Compose automatically reads a file named `docker-compose.override.yml`
+#   (this file's name, minus the `.example`) and layers it on top of the shipped
+#   docker-compose.yml. CozyVTT's .gitignore excludes that filename, so updates
+#   with `git pull` will never conflict with your changes.
+#
+# HOW TO USE IT
+#   1. cp docker-compose.override.example.yml docker-compose.override.yml
+#   2. Edit your copy — delete anything you don't need
+#   3. docker compose up -d
+#   4. docker compose config    # shows the merged result, to confirm it worked
+#
+#   No -f flags needed. (If you DO pass -f yourself, you must list both files:
+#   docker compose -f docker-compose.yml -f docker-compose.override.yml up -d)
+#
+# WHAT BELONGS HERE
+#   Only the settings you are changing — not a copy of docker-compose.yml.
+#   Adding or changing settings works naturally. REMOVING a service does not:
+#   Compose can only add or change, never delete. See the nginx example below.
+#
+# The example below is the common "I use my own reverse proxy / Cloudflare
+# Tunnel" setup. See docs/DEPLOYMENT.md → "Using an External Reverse Proxy".
+# ============================================================================
+
+services:
+  # ---- Turn off the bundled Nginx ------------------------------------------
+  # You can't delete a service from here, but tagging it with a profile keeps it
+  # from starting: a service with a profile only runs when that profile is
+  # switched on, and nothing switches this one on.
+  #
+  # Only do this if your own proxy handles the routing that nginx normally does:
+  #   /api/...        -> backend
+  #   /socket.io/...  -> backend
+  #   everything else -> frontend
+  nginx:
+    profiles: ["disabled"]
+
+  # ---- Open ports so your proxy can reach the containers -------------------
+  # As shipped, the backend and frontend are only reachable from inside Docker
+  # (that's what `expose` means). Removing nginx leaves nothing open, so your
+  # proxy would have nothing to connect to. These lines open them.
+  #
+  # Read "127.0.0.1:4000:4000" as: port 4000 inside the container becomes port
+  # 4000 on this server, reachable ONLY from this server itself.
+  #
+  # KEEP the 127.0.0.1: prefix. Without it the API is published on your public
+  # IP over plain HTTP, bypassing your proxy entirely. Note that a firewall does
+  # not reliably help here — Docker's published ports bypass UFW.
+  #
+  # Not needed if your proxy runs in Docker on the same network (it can reach
+  # `backend:4000` and `frontend:80` by name) — see Option B in the docs.
+  backend:
+    ports:
+      - "127.0.0.1:4000:4000"
+
+  frontend:
+    ports:
+      - "127.0.0.1:8080:80"
+
+# ---- Other things people commonly put here ---------------------------------
+# Uncomment and adapt as needed.
+#
+# Pin the database to a specific host port for backups or an external tool:
+#   database:
+#     ports:
+#       - "127.0.0.1:5432:5432"
+#
+# Give the backend more memory than the default 512M limit:
+#   backend:
+#     deploy:
+#       resources:
+#         limits:
+#           memory: 1G
+#
+# Add an extra environment variable to the backend:
+#   backend:
+#     environment:
+#       LOG_LEVEL: debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,17 +5,27 @@
 # For development (hot-reload, exposed ports), use:
 #   docker compose -f docker-compose.dev.yml up
 #
+# Prefer not to edit this file: personal tweaks belong in docker-compose.override.yml,
+# which Compose merges automatically and git ignores — so `git pull` never conflicts.
+# Copy docker-compose.override.example.yml to get started.
+#
 # If you have a reverse proxy that handles INTERNAL routing too
 # (Traefik, Caddy, an existing host-level Nginx): you can remove the bundled
-# nginx service below. Then:
-#   - Change `expose` to `ports` on the frontend service so your proxy can reach it
-#   - Point your proxy at frontend:80 for the SPA and backend:4000 for /api + /socket.io
+# nginx service below. Then ALL of the following are required:
+#   - Add `ports` to the BACKEND service (e.g. "127.0.0.1:4000:4000") — it is
+#     `expose`-only by default, so nothing outside Docker can reach it and your
+#     proxy would be pointing at a closed port
+#   - Add `ports` to the FRONTEND service (e.g. "127.0.0.1:8080:80")
+#   - Route /api/* AND /socket.io/* to the backend, everything else to the frontend
+# Miss any of these and the site loads but the API is unreachable: a fresh install
+# shows the login page instead of the setup wizard, or setup fails with a 502.
 #
-# Cloudflare Tunnel users: KEEP the bundled nginx. CF Tunnel only handles
-# public-facing TLS and origin hiding; you still need the bundled nginx to
-# route between the frontend SPA and the backend API/WebSocket. Just point
-# your `cloudflared` ingress at http://localhost:80 and you're done.
-# See docs/DEPLOYMENT.md for details.
+# Cloudflare Tunnel users: the simplest setup is to KEEP the bundled nginx —
+# CF Tunnel handles public-facing TLS and origin hiding, but not the routing
+# between the frontend SPA and the backend API/WebSocket. Point your
+# `cloudflared` ingress at http://localhost:80 and you're done. To run without
+# nginx you need path-based ingress rules (specific paths first, catch-all last).
+# See docs/DEPLOYMENT.md → "Using an External Reverse Proxy" for all three setups.
 
 services:
   database:

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -865,9 +865,10 @@ List all users on the platform.
 
 ---
 
-### `POST /api/users` *(Admin only)*
+### `POST /api/admin/users` *(Admin only)*
 
-Create a new user account. Returns a generated temporary password.
+Create a new user account with a generated temporary password. The account is flagged
+`mustChangePassword`, so that password can only be used to set a real one.
 
 **Request:**
 ```json
@@ -875,6 +876,59 @@ Create a new user account. Returns a generated temporary password.
   "email": "newplayer@example.com",
   "displayName": "New Player",
   "platformRole": "USER"
+}
+```
+
+**Response:**
+```json
+{
+  "message": "User created. Sign-in details were emailed to newplayer@example.com.",
+  "user": { "id": "…", "email": "newplayer@example.com", "…": "…" },
+  "emailSent": true
+}
+```
+
+`temporaryPassword` is included **only when `emailSent` is false** — that is, when SMTP is not configured or delivery failed and the admin has no other way to hand it over. When the welcome email went out, the password is withheld so the admin never holds a working credential for another account.
+
+---
+
+### `POST /api/admin/users/invite` *(Admin only)*
+
+Invite a user by email. The account is created **without a usable password**; the emailed link is the only way in, and it expires in **7 days**. Nothing password-related is returned.
+
+Requires SMTP — returns `503` when it isn't configured. If the email fails to send, the account is rolled back rather than left unreachable (`502`).
+
+**Request:**
+```json
+{
+  "email": "newplayer@example.com",
+  "displayName": "New Player",
+  "platformRole": "USER"
+}
+```
+
+**Response:**
+```json
+{
+  "message": "Invitation sent to newplayer@example.com",
+  "user": { "id": "…", "email": "newplayer@example.com", "…": "…" },
+  "expiresInDays": 7
+}
+```
+
+The recipient opens `/accept-invite?token=…` and sets a password, which is completed through `POST /api/auth/reset-password` — invitations and resets share the same token machinery.
+
+---
+
+### `POST /api/admin/users/:id/resend-invite` *(Admin only)*
+
+Issue a fresh invitation link, invalidating any outstanding one. Requires SMTP (`503` otherwise).
+
+**Response:**
+```json
+{
+  "message": "Invitation resent to newplayer@example.com",
+  "expiresInDays": 7
 }
 ```
 
@@ -888,7 +942,9 @@ Update a user's platform role or approval status.
 
 ### `POST /api/users/:id/reset-password` *(Admin only)*
 
-Generate a temporary password for a user. The user must change it on next login.
+Generate a temporary password for a user. The account is flagged `mustChangePassword`, and **any
+sessions the user currently has open are signed out** — otherwise they would keep browsing on the
+old session and the forced change would only apply at their next login.
 
 **Response:**
 ```json
@@ -1190,6 +1246,28 @@ All error responses follow this shape:
 | `409` | Conflict — e.g., email already in use |
 | `429` | Rate limit exceeded |
 | `500` | Server error — check server logs |
+| `502` | Upstream failure — e.g., an invitation email could not be delivered |
+| `503` | Feature unavailable — e.g., an email-dependent endpoint with no SMTP configured |
+
+### Password change required
+
+Accounts an admin created, or whose password an admin reset, must set a new password before doing
+anything else. Until they do, **every endpoint except the ones needed to change it** returns:
+
+```json
+{
+  "error": "Password Change Required",
+  "code": "PASSWORD_CHANGE_REQUIRED",
+  "message": "You must set a new password before continuing."
+}
+```
+
+Status `403`. Still reachable while in this state: `POST /api/auth/change-password`,
+`POST /api/auth/logout`, `GET /api/auth/me`, `GET /api/auth/ping`, `GET /api/auth/appearance`, and
+`GET /api/config`. WebSocket connections are refused on the same basis.
+
+Clients should route on `code`, not the message — the web app redirects to its change-password screen
+when it sees it.
 
 ---
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -402,7 +402,7 @@ Upload a `.cozyvtt` archive and return its manifest preview without creating any
   "preview": {
     "formatVersion": 1,
     "exportedAt": "2026-04-18T12:00:00.000Z",
-    "exportedFrom": "CozyVTT v1.1.1",
+    "exportedFrom": "CozyVTT v1.1.2",
     "campaignName": "The Lost Mines",
     "gameSystem": "DND_5E",
     "mapCount": 5,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -172,6 +172,39 @@ CozyVTT uses three complementary state layers, each with a clear boundary. The r
 
 The split exists for performance. Live token movement is written to the Zustand store from **outside** React, so a `token.moved` event re-renders only the components subscribed to that token (the map canvas) — the roster, initiative tracker, and side panels don't re-render per movement frame. All three context provider values are memoized so unrelated socket traffic doesn't cascade re-renders through the campaign subtree.
 
+### Theming
+
+Every color in the themed UI comes from a CSS variable, so switching themes repaints the app without
+re-rendering anything. Tailwind maps each token with `rgb(var(--color-x) / <alpha-value>)`
+([tailwind.config.js](../frontend/tailwind.config.js)), which is why opacity modifiers such as
+`bg-danger/10` still follow the theme.
+
+| Group | Tokens | Use for |
+|---|---|---|
+| Brand / accent | `brand`, `brand-dark`, `accent`, `accent-hover`, `accent-text` | Fills: buttons, borders, highlights |
+| Text | `ink`, `ink-secondary`, `ink-muted` | Body, secondary and muted text |
+| Surfaces | `canvas`, `surface`, `surface-light`, `surface-dark`, `paper` | Page and panel backgrounds |
+| **Ink variants** | `brand-ink`, `accent-ink`, `spirit-ink`, `danger-ink`, `success-ink`, `warning-ink`, `info-ink` | **Text** in that color |
+| States | `danger`, `success`, `warning`, `info`, `spirit` | Status fills, borders, tints |
+
+**Two rules keep themes readable:**
+
+1. **Use `-ink` when the color is text.** `accent` is a fill — as text it measured as low as 1.84:1.
+   The `-ink` variants are derived per theme by `deriveReadableTokens`
+   ([themes.ts](../frontend/src/themes.ts)) via `ensureReadable`
+   ([utils/color.ts](../frontend/src/utils/color.ts)), which walks the color's lightness until it
+   clears WCAG AA against that theme's surfaces. Authored values that already pass are left alone.
+   Custom themes get the same treatment, so a user-picked palette cannot produce unreadable text.
+2. **Never use a raw Tailwind palette color on a themed surface.** `bg-red-50` stays pale pink on a
+   dark theme. Use the state tokens, or the `.alert-*` / `.badge-*` classes in
+   [index.css](../frontend/src/index.css).
+
+Both rules are enforced by tests rather than review:
+`utils/__tests__/themes.contrast.test.ts` checks every preset theme against every text/background
+pair the UI renders, and `utils/__tests__/themeTokens.test.ts` fails if raw palette colors appear
+outside the two exempt areas (character sheets, which are deliberately styled as light "paper" cards,
+and the dark DM map overlays).
+
 ### Data Flow (Campaign Page)
 
 ```mermaid

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,6 +61,7 @@ src/
 ├── config/            Configuration loading (env vars, validation)
 ├── middleware/
 │   ├── auth.ts        Passport.js session middleware, requireAuth guards
+│   ├── passwordChange.ts  Gates every route until an admin-issued password is replaced
 │   ├── rateLimit.ts   Per-route rate limiters (auth, dice, chat, file upload)
 │   └── upload.ts      Multer configuration, magic byte validation
 ├── routes/            HTTP route handlers

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -49,6 +49,27 @@ If you become a collaborator, here's what the codebase expects:
 - File uploads must go through the existing magic byte validation middleware
 - Any new WebSocket events that modify state must verify campaign membership server-side
 
+### Styling and themes
+
+CozyVTT ships 16 themes, including four dark ones, plus user-defined custom colors. Two rules keep
+every screen working across all of them — both are enforced by tests, so breaking them fails the
+build rather than showing up as an unreadable screen for someone using a theme you didn't try:
+
+- **Never use a raw Tailwind palette color** (`bg-red-50`, `text-stone-500`, `text-blue-600`) in
+  themed UI. They keep their light-mode appearance on dark themes. Use the semantic tokens —
+  `danger`, `success`, `warning`, `info`, `spirit` — or the `.alert-*` and `.badge-*` classes in
+  `frontend/src/index.css`.
+- **Use the `-ink` variant when the color is text**: `text-danger-ink`, not `text-danger`;
+  `text-brand-ink`, not `text-moss-green`. The plain token is a fill (buttons, borders, tints); the
+  `-ink` version is derived per theme to stay above WCAG AA against that theme's backgrounds.
+
+Two areas are deliberately exempt and listed in `utils/__tests__/themeTokens.test.ts`: the character
+sheets (styled as light "paper" cards, matching the physical sheets) and the dark DM overlays that
+float over the map. If you add UI there, check its contrast by hand — exempt from theming is not
+exempt from being readable.
+
+See [ARCHITECTURE.md → Theming](ARCHITECTURE.md#theming) for the full token list.
+
 ### Performance
 
 - Avoid blocking the event loop in route handlers — use `async/await` with Prisma

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -540,7 +540,7 @@ openssl rand -hex 32
 
 ### SMTP Setup (Optional)
 
-Email is required for password reset and invitation notifications. Configure in `.env`:
+Email is required for password resets and invitations. Configure in `.env`:
 
 ```env
 SMTP_HOST=smtp.example.com
@@ -554,7 +554,19 @@ APP_URL=https://your-domain.com
 
 Test from **Admin Dashboard → Settings → Test Email** after deploying.
 
-If SMTP is not configured, admin-initiated password resets still work — the admin generates a temporary password from the Users tab.
+#### What SMTP unlocks
+
+| Feature | With SMTP | Without SMTP |
+|---|---|---|
+| **Adding a user** | **Invite User** — they get an email with a link and choose their own password. Nobody else ever sees it. | **Create User** — a temporary password is generated and shown to you once, to hand over yourself |
+| Password resets (self-service) | User clicks "Forgot password" and gets a reset link | Unavailable — the user has to ask an admin |
+| Password resets (admin) | Email the user a reset link, or generate a temporary password | Generate a temporary password from the Users tab |
+| Campaign invitations | Emailed to the player | Share the invite link manually |
+
+Either way, an account created by an admin **must set its own password on first sign-in** — the
+temporary password works for nothing else, so an admin never keeps usable access to someone's
+account. Invitation links are valid for **7 days**; use **Invite** on the Users tab to send a fresh
+one if it expires.
 
 ### Upload Size Limits
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -18,8 +18,9 @@ This guide covers deploying CozyVTT to a **production server** using Docker Comp
 8. [File Storage](#file-storage)
 9. [Database Backups](#database-backups)
 10. [Monitoring and Logs](#monitoring-and-logs)
-11. [Updating CozyVTT](#updating-cozyvtt)
-12. [Hardening Checklist](#hardening-checklist)
+11. [Troubleshooting](#troubleshooting)
+12. [Updating CozyVTT](#updating-cozyvtt)
+13. [Hardening Checklist](#hardening-checklist)
 
 ---
 
@@ -92,8 +93,16 @@ docker compose ps
 docker compose logs backend | grep -i migrat
 
 # Health check (returns {"status":"healthy",...})
-curl http://localhost/health
+docker compose exec backend wget -qO- http://localhost:4000/health
+
+# The API answers on the same address as the site — this must be JSON, not a web page
+curl -si http://localhost/api/setup/status | head -3
 ```
+
+That last check should show `content-type: application/json` followed by something like
+`{"setupCompleted":false,"hasUsers":false,"needsSetup":true}`. If it shows `content-type: text/html`,
+your `/api` requests are landing on the web pages instead of the API — see
+[Using an External Reverse Proxy](#using-an-external-reverse-proxy).
 
 ### Stopping and Starting
 
@@ -125,21 +134,71 @@ The defaults (`80`/`443`) apply if these variables are not set.
 
 If you already run a reverse proxy (Traefik, Caddy, another Nginx, or a Cloudflare Tunnel), you don't need the bundled `nginx` service.
 
-**Option A — Remove the nginx service and expose the frontend directly:**
+### First, the one thing that trips everyone up
 
-1. Delete the `nginx` service block from `docker-compose.yml`
-2. Change the `frontend` service from `expose` to `ports`:
+CozyVTT runs as three pieces: a **frontend** (the web pages you see), a **backend** (the API and live game connection), and a **database**. Your browser talks to both the frontend and the backend, on the same web address:
+
+| Web address | Must reach |
+|---|---|
+| `/api/...` | the **backend** |
+| `/socket.io/...` | the **backend** (this is the live connection — dice rolls, token movement, chat) |
+| everything else | the **frontend** |
+
+The bundled `nginx` service is what normally does that splitting. **If you remove it, your own proxy has to do all three lines above.**
+
+There's a second catch. Out of the box, the backend and frontend use `expose`, which means *"other containers can reach me"* — **not** *"the outside world can reach me."* The bundled nginx is the only piece with `ports`, which is what actually opens a port on your server. So when you delete the nginx service, you also have to open ports on the backend and frontend yourself, or your proxy will be pointing at nothing.
+
+> **If you miss this:** the site loads and looks fine, but the setup wizard never appears (you get a login page you can't use), or setup fails with **502**. That's the API being unreachable — the pages come from the frontend, which is still working.
+
+### Option A — Remove the nginx service (most common)
+
+1. **Delete the `nginx` service block** from `docker-compose.yml` (the whole `nginx:` section).
+
+2. **Open ports on the backend and frontend.** In `docker-compose.yml`, replace the `expose` block in each service with `ports`:
+
    ```yaml
-   ports:
-     - "8080:80"   # or whichever port your proxy can reach
+     backend:
+       # ...
+       ports:
+         - "127.0.0.1:4000:4000"     # was: expose: - "4000"
+
+     frontend:
+       # ...
+       ports:
+         - "127.0.0.1:8080:80"       # was: expose: - "80"
    ```
-3. Point your proxy to:
-   - `/api/*` and `/socket.io/*` → `backend:4000` (or `localhost:4000` from the host)
-   - Everything else → `frontend:80` (or `localhost:8080`)
 
-**Option B — Shared Docker network (recommended for Traefik/Caddy):**
+   Read `"127.0.0.1:8080:80"` as: *port 80 inside the container becomes port 8080 on this server, reachable only from this server itself.*
 
-1. Remove the `nginx` service from `docker-compose.yml`
+   > 🔒 **Keep the `127.0.0.1:` prefix.** Without it (`"4000:4000"`), your API is published on your server's public IP over plain, unencrypted HTTP — anyone who finds it bypasses your proxy entirely, along with any protection it provides. The `CORS_ORIGIN` setting does **not** protect against this; it only restricts browsers, not tools like `curl`.
+   >
+   > A firewall is not a substitute here: **Docker's published ports bypass UFW**, so a rule like `ufw deny 4000` usually does *not* block a port published this way. The `127.0.0.1:` prefix is the reliable control.
+
+3. **Point your proxy at those ports:**
+
+   | Requests for | Send to |
+   |---|---|
+   | `/api/...` | `http://localhost:4000` |
+   | `/socket.io/...` | `http://localhost:4000` |
+   | everything else | `http://localhost:8080` |
+
+4. **Restart and check it worked:**
+
+   ```bash
+   docker compose down     # also stops the old nginx container
+   docker compose up -d
+   curl -si https://your-domain.com/api/setup/status | head -3
+   ```
+
+   Use `down` first: deleting the `nginx` block from the file does **not** stop a container that is already running, and a leftover nginx still holding port 80 will confuse things. Your database is stored in a volume and is not affected by `down` (only `down -v` would erase it).
+
+   You should see `content-type: application/json` and a line like `{"setupCompleted":false,...}`. If you see `content-type: text/html`, your proxy is sending `/api` to the frontend instead of the backend. If you see `502`, nothing is listening where your proxy is pointing — usually step 2 was skipped.
+
+### Option B — Shared Docker network (recommended for Traefik/Caddy)
+
+If your proxy also runs in Docker, this is cleaner: it talks to the containers directly by name, and **no ports need to be opened at all**.
+
+1. Remove the `nginx` service block from `docker-compose.yml`
 2. Add your proxy's network to both `frontend` and `backend` services:
    ```yaml
    networks:
@@ -154,21 +213,143 @@ If you already run a reverse proxy (Traefik, Caddy, another Nginx, or a Cloudfla
      proxy:
        external: true
    ```
-4. Configure your proxy to route to `frontend:80` and `backend:4000` by container name.
+4. Configure your proxy to route to `frontend:80` and `backend:4000` by container name — same three routing lines from the table above.
 
-**Cloudflare Tunnel:**
+### Cloudflare Tunnel
 
-Use Option A or B above. Cloudflare Tunnel does not require ports 80 or 443 to be open on your host — `cloudflared` makes outbound connections to Cloudflare's network, so no inbound firewall rules are needed.
+`cloudflared` makes an outbound connection to Cloudflare, so no inbound ports need to be open on your server's firewall. There are three ways to set it up — pick one:
+
+**1. Keep the bundled nginx (simplest, recommended).** Leave `docker-compose.yml` exactly as shipped and point the tunnel at it. One rule, nothing to open, and nginx handles the `/api` vs `/socket.io` vs frontend split for you:
+
+```yaml
+# ~/.cloudflared/config.yml
+ingress:
+  - hostname: cozyvtt.example.com
+    service: http://localhost:80        # or your HTTP_PORT
+  - service: http_status:404
+```
+
+This is also the option that keeps upload limits (`NGINX_MAX_BODY_SIZE`) and secure-cookie headers working without extra configuration.
+
+**2. Run `cloudflared` as a container** on CozyVTT's own Docker network. Nothing is published to the host at all — the tunnel reaches the containers by name:
+
+```yaml
+ingress:
+  - hostname: cozyvtt.example.com
+    path: ^/api/
+    service: http://backend:4000
+  - hostname: cozyvtt.example.com
+    path: ^/socket.io/
+    service: http://backend:4000
+  - hostname: cozyvtt.example.com
+    service: http://frontend:80
+  - service: http_status:404
+```
+
+> ⚠️ Inside a container, `localhost` means *that container itself*, not your server. Use the service names (`backend`, `frontend`) as above — `http://localhost:4000` will fail here.
+
+**3. `cloudflared` installed on the server** (not in Docker), with the ports from Option A step 2 opened:
+
+```yaml
+ingress:
+  - hostname: cozyvtt.example.com
+    path: ^/api/
+    service: http://localhost:4000
+  - hostname: cozyvtt.example.com
+    path: ^/socket.io/
+    service: http://localhost:4000
+  - hostname: cozyvtt.example.com        # catch-all — must be LAST
+    service: http://localhost:8080
+  - service: http_status:404
+```
+
+**Rule order matters.** Cloudflare reads ingress rules top to bottom and uses the **first** one that matches. A rule with only a `hostname` matches *everything* for that domain, so if you put it above the `path` rules, it swallows `/api` and `/socket.io` — and you get the "login page instead of setup wizard" symptom. Always list the specific `path` rules first and the catch-all last.
+
+`path: ^/api/` is a pattern meaning *"any address starting with `/api/`"*. Keep it exactly as written.
+
+After editing `~/.cloudflared/config.yml`, restart the tunnel and re-run the check from Option A step 4:
+
+```bash
+sudo systemctl restart cloudflared
+curl -si https://cozyvtt.example.com/api/setup/status | head -3
+```
 
 ### Minimum proxy requirements
 
 Whatever proxy you use, it must:
-- Forward `/api/*` and `/socket.io/*` to the backend
+- Forward `/api/*` and `/socket.io/*` to the backend, and everything else to the frontend
 - Support WebSocket upgrades (`Upgrade: websocket` / `Connection: upgrade`) on the `/socket.io/` path
 - Pass `X-Forwarded-For` and `X-Forwarded-Proto` headers to the backend
 - Allow request bodies of at least **55 MB** (covers the default `MAX_MAP_SIZE_MB=50` plus overhead), and more if you raise any `MAX_*_SIZE_MB` — see [Upload Size Limits](#upload-size-limits)
 
+> ⚠️ **A proxy that only serves the web pages looks like it works.** If `/api` isn't routed to the backend, those requests come back as the CozyVTT web page itself with a success code, so the site loads normally while every API call quietly fails. Symptoms: a brand-new install shows the login page instead of the setup wizard, and `/setup` bounces straight back to the home page. The `curl` check above tells you in one command.
+
 > ⚠️ **Cloudflare users:** Cloudflare-proxied requests — including Cloudflare Tunnel — are capped at **100 MB** per request body on Free and Pro plans. Uploads above that are rejected at Cloudflare's edge no matter how CozyVTT or your proxy is configured.
+
+### Updating after you've edited `docker-compose.yml`
+
+Once you've changed `docker-compose.yml`, a plain `git pull` will stop and complain, because your changes and ours are both in that file:
+
+```
+error: Your local changes to the following files would be overwritten by merge:
+        docker-compose.yml
+Please commit your changes or stash them before you merge.
+```
+
+Set your changes aside, update, then put them back:
+
+```bash
+git stash          # tuck your edits away
+git pull           # get the update
+git stash pop      # re-apply your edits
+```
+
+If `git stash pop` reports a conflict, the file will contain both versions marked with `<<<<<<<` and `>>>>>>>` lines — open it, keep the lines you want, delete the markers, then `docker compose up -d --build`.
+
+> ⚠️ **Don't "fix" this with `git checkout -- docker-compose.yml`.** That throws your customizations away and restores the shipped file — you'd lose your ports, your proxy setup, everything you changed.
+
+### Optional: avoid the conflicts entirely (advanced)
+
+If you update often and would rather never deal with the above, Docker Compose can read a **second, personal file** that sits on top of the shipped one. Name it `docker-compose.override.yml` and put it next to `docker-compose.yml`; `docker compose up -d` picks it up automatically, and CozyVTT's `.gitignore` already excludes it, so `git pull` will never touch it.
+
+Copy the ready-made example to get started:
+
+```bash
+cp docker-compose.override.example.yml docker-compose.override.yml
+```
+
+It contains only the settings you're changing — **not** a copy of the whole file:
+
+```yaml
+services:
+  nginx:
+    profiles: ["disabled"]              # keeps nginx from starting
+  backend:
+    ports:
+      - "127.0.0.1:4000:4000"
+  frontend:
+    ports:
+      - "127.0.0.1:8080:80"
+```
+
+Two things to know:
+
+- **Adding settings works naturally.** The `ports` lines above are simply added to the shipped configuration. You leave `docker-compose.yml` untouched, so it updates cleanly forever.
+- **Removing a service doesn't.** There's no way to delete something in this second file — it can only add or change. The `profiles: ["disabled"]` line above is the workaround: it tags the nginx service so it never starts. (If you'd rather not use that, you can leave the line out and start CozyVTT with `docker compose up -d database backend frontend`, naming the services you want — but you have to remember it every time.)
+
+Check that it did what you expect, then restart:
+
+```bash
+docker compose config --services   # lists what will run — nginx should be absent
+docker compose config              # shows the full merged configuration
+
+docker compose down                # stops the currently-running nginx
+docker compose up -d
+```
+
+`down` is needed the first time because an nginx container that is already running keeps running until it is stopped — the profile only controls what *starts*.
+
+> One catch: this automatic pickup only happens when you run plain `docker compose` commands. If you pass `-f` yourself, list both files: `docker compose -f docker-compose.yml -f docker-compose.override.yml up -d`.
 
 ---
 
@@ -493,14 +674,68 @@ Returns `200 OK` when healthy:
 
 Returns `503` with `"status": "degraded"` if the database is unreachable. Useful for uptime monitors and load balancer health probes.
 
+This endpoint lives on the **backend**, which the bundled Nginx does not forward — so on a default install, check it from inside the stack:
+
 ```bash
-curl http://your-server/health
+docker compose exec backend wget -qO- http://localhost:4000/health
 ```
+
+Docker already runs this check for you every 30 seconds; `docker compose ps` shows the backend as `healthy` or `unhealthy` based on it.
+
+If you run your own reverse proxy and want an uptime monitor to reach `/health` from outside, add a route for it alongside your `/api` route, both pointing at the backend.
 
 ### Database Connectivity
 
 ```bash
 docker compose exec database pg_isready -U cozyvtt
+```
+
+---
+
+## Troubleshooting
+
+### A brand-new install shows the login page instead of the setup wizard
+
+…and going to `/setup` sends you straight back to the home page.
+
+**Cause:** your `/api` requests aren't reaching the backend, so the app can't tell that this is a new installation. Almost always a reverse-proxy routing problem, not a CozyVTT problem.
+
+**Check it:**
+
+```bash
+curl -si https://your-domain.com/api/setup/status | head -3
+```
+
+| What you see | What it means | Fix |
+|---|---|---|
+| `content-type: application/json` | The API is fine — the problem is elsewhere | Check `docker compose logs backend` |
+| `content-type: text/html` | `/api` is being answered by the web pages instead of the backend | Add the `/api/...` → backend route to your proxy |
+| `502` or a connection error | Nothing is listening where your proxy points | Open the backend port — see [Option A](#option-a--remove-the-nginx-service-most-common) step 2 |
+
+### Setup fails with "An error occurred during setup" (502)
+
+Same root cause as above: the browser reached the wizard (served by the frontend), but the request that creates your admin account goes to the backend, which your proxy can't reach. Run the same check.
+
+If you removed the bundled `nginx` service, the usual culprit is a missing `ports` entry on the **backend** service — it is `expose`-only by default, which means "reachable from other containers" but not from your proxy.
+
+### Live features don't work (dice, token movement, chat)
+
+The page loads and you can log in, but nothing updates in real time. Your proxy is routing `/api` but not `/socket.io`. Add the `/socket.io/...` → backend route, and make sure your proxy allows WebSocket upgrades.
+
+### `git pull` refuses to update because of local changes
+
+```
+error: Your local changes to the following files would be overwritten by merge
+```
+
+You edited a tracked file (usually `docker-compose.yml`). See [Updating after you've edited `docker-compose.yml`](#updating-after-youve-edited-docker-composeyml).
+
+### Uploads fail on large files
+
+Check [Upload Size Limits](#upload-size-limits). The backend logs its effective limits at startup and warns when your proxy's body limit is smaller than they are:
+
+```bash
+docker compose logs backend | grep -i "upload limits"
 ```
 
 ---
@@ -598,11 +833,17 @@ If CozyVTT is reachable from the internet, fronting it with a **[Cloudflare Tunn
        service: http://localhost:80   # or whatever HTTP_PORT you set
      - service: http_status:404
    ```
+   > This single rule assumes you kept the bundled `nginx` service, which is the recommended setup — it splits `/api` and `/socket.io` off to the backend for you. **If you removed nginx**, one rule is not enough; you need path-based rules in a specific order, plus published ports. See [Cloudflare Tunnel](#cloudflare-tunnel) under "Using an External Reverse Proxy".
 6. Run as a service:
    ```bash
    sudo cloudflared service install
    sudo systemctl start cloudflared
    ```
+7. Confirm the API is reachable through the tunnel, not just the web pages:
+   ```bash
+   curl -si https://cozyvtt.example.com/api/setup/status | head -3
+   ```
+   You want `content-type: application/json`. Anything else means the tunnel isn't reaching the backend — see [Troubleshooting](#troubleshooting).
 
 Once running, you can **close ports 80 and 443 on your VPS firewall entirely** — only SSH (port 22, or your chosen alternative) needs to be reachable, and even that you can put behind Cloudflare Access if you want.
 

--- a/docs/PLAYER_GUIDE.md
+++ b/docs/PLAYER_GUIDE.md
@@ -24,16 +24,23 @@ No technical knowledge required. Let's go.
 
 ## Getting Your Account
 
-Your platform administrator (or your DM, if they're also the admin) will create an account for you and send you login credentials. You'll receive:
+Your platform administrator (or your DM, if they're also the admin) sets up your account. Depending on how their instance is configured, you'll get one of two things by email.
 
-- The URL for your CozyVTT instance
-- Your email address
-- A temporary password
+**If you receive an invitation link** (most common):
 
-**First login:**
+1. Click **Accept Invitation** in the email
+2. Choose your own password — nobody else ever sees it
+3. Sign in with your email and that password
+
+The link is valid for **7 days**. If it expires, ask your administrator to send another.
+
+**If you receive a temporary password instead:**
+
 1. Go to the CozyVTT URL
-2. Log in with your email and temporary password
-3. You'll be prompted to change your password — pick something you'll actually remember
+2. Sign in with your email and the temporary password
+3. You'll be asked immediately to choose your own password — this is required, and until you do, the temporary one won't get you anywhere else in the app
+
+Either way you end up with a password only you know. Pick something you'll actually remember.
 
 *Screenshot pending — Login page.*
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -444,7 +444,7 @@ CozyVTT theming works in two layers:
 
 - **Default theme** — 16 built-in themes spanning warm, cool, dark, neutral, and vibrant palettes
 - **Default font** — 8 open-source font families (Quicksand + Inter default, plus medieval, elegant, handwritten, etc.)
-- **Custom theme builder** — primary, accent, background, and text colors; complementary shades derived automatically
+- **Custom theme builder** — primary, accent, background, and text colors; complementary shades derived automatically. The picker shows a live **Readability** check with the contrast ratio of each key text/background pair, flagging anything below the 4.5:1 minimum, and CozyVTT adjusts text shades automatically where it can
 - **Custom branding** — logo, mascot, and favicon shown on the login page and across the instance (always system-wide regardless of user theme)
 
 Changes preview live as you configure them.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -63,7 +63,9 @@ Navigate to your CozyVTT URL and enter your email and password. If Multi-Factor 
 
 *GIF pending — Login flow with MFA step.*
 
-**Forgot your password?** Contact your platform administrator — they can generate a temporary password from the Admin Panel.
+**Forgot your password?** If your instance has email configured, use **Forgot password** on the login page. Otherwise contact your platform administrator, who can email you a reset link or generate a temporary password from the Admin Panel.
+
+**First time signing in?** An account someone else created for you always ends its first sign-in with you choosing your own password. Until you do, the temporary password you were given won't open anything else — so nobody, including the admin who created the account, keeps a way in.
 
 ---
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cozyvtt-frontend",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cozyvtt-frontend",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "@tanstack/react-query": "^5.101.2",
         "axios": "^1.6.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozyvtt-frontend",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "description": "CozyVTT Frontend - Self-hosted Virtual Tabletop",
   "private": true,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ const LoginPage           = lazy(() => import('@/pages/auth/LoginPage'));
 const RegisterPage        = lazy(() => import('@/pages/auth/RegisterPage'));
 const ForgotPasswordPage  = lazy(() => import('@/pages/auth/ForgotPasswordPage'));
 const ResetPasswordPage   = lazy(() => import('@/pages/auth/ResetPasswordPage'));
+const ChangePasswordPage  = lazy(() => import('@/pages/auth/ChangePasswordPage'));
 const MFAVerifyPage       = lazy(() => import('@/pages/auth/MFAVerifyPage'));
 const MFASetupPage     = lazy(() => import('@/pages/MFASetupPage'));
 const SetupWizardPage  = lazy(() => import('@/pages/SetupWizardPage'));
@@ -84,8 +85,12 @@ function App() {
           <Route path="/auth/register" element={<RegisterPage />} />
           <Route path="/auth/forgot-password" element={<ForgotPasswordPage />} />
           <Route path="/reset-password" element={<ResetPasswordPage />} />
+          <Route path="/accept-invite" element={<ResetPasswordPage invite />} />
           <Route path="/auth/mfa-verify" element={<MFAVerifyPage />} />
           <Route path="/auth/mfa-setup" element={<MFASetupPage />} />
+          {/* Signed in, but the account still has to replace an admin-issued
+              password — the server rejects everything else until it does */}
+          <Route path="/auth/change-password" element={<ChangePasswordPage />} />
 
           {/* Protected Routes - Require Authentication */}
           <Route

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,7 +46,7 @@ function PageLoader() {
       aria-live="polite"
       aria-label="Loading page"
     >
-      <Loader2 className="w-8 h-8 text-moss-green animate-spin" aria-hidden="true" />
+      <Loader2 className="w-8 h-8 text-brand-ink animate-spin" aria-hidden="true" />
     </div>
   );
 }
@@ -212,7 +212,7 @@ function WelcomePage() {
           <MascotImage className="w-16 h-16 animate-pulse-soft" />
         </div>
         <div>
-          <h1 className="text-4xl font-bold text-moss-green font-heading text-shadow-soft">
+          <h1 className="text-4xl font-bold text-brand-ink font-heading text-shadow-soft">
             CozyVTT
           </h1>
           <p className="mt-2 text-warm-gray">

--- a/frontend/src/components/CampaignCard.tsx
+++ b/frontend/src/components/CampaignCard.tsx
@@ -26,7 +26,7 @@ export default function CampaignCard({ campaign, userRole }: CampaignCardProps) 
       },
       ACTIVE: {
         label: 'Active',
-        class: 'bg-moss-green/20 text-moss-green border-moss-green/30',
+        class: 'bg-moss-green/20 text-brand-ink border-moss-green/30',
       },
       PAUSED: {
         label: 'Paused',
@@ -55,7 +55,7 @@ export default function CampaignCard({ campaign, userRole }: CampaignCardProps) 
       DM: {
         label: 'DM',
         icon: Crown,
-        class: 'bg-moss-green/20 text-moss-green border-moss-green/40',
+        class: 'bg-moss-green/20 text-brand-ink border-moss-green/40',
       },
       PLAYER: {
         label: 'Player',
@@ -119,7 +119,7 @@ export default function CampaignCard({ campaign, userRole }: CampaignCardProps) 
       </div>
 
       {/* Campaign Name */}
-      <h3 className="text-xl font-semibold text-moss-green mb-2 pr-20
+      <h3 className="text-xl font-semibold text-brand-ink mb-2 pr-20
                      group-hover:text-spirit-purple transition-colors">
         {campaign.name}
       </h3>
@@ -143,7 +143,7 @@ export default function CampaignCard({ campaign, userRole }: CampaignCardProps) 
       <div className="space-y-2 text-sm">
         {/* DM Name */}
         <div className="flex items-center gap-2 text-stone-gray">
-          <Crown className="w-4 h-4 text-moss-green" />
+          <Crown className="w-4 h-4 text-brand-ink" />
           <span className="text-warm-gray">DM:</span>
           <span className="text-stone-gray font-medium">{ownerName}</span>
         </div>

--- a/frontend/src/components/ConnectionStatus.tsx
+++ b/frontend/src/components/ConnectionStatus.tsx
@@ -16,7 +16,7 @@ export default function ConnectionStatus() {
   // Don't show anything when fully connected
   if (status === 'connected') {
     return (
-      <div className="flex items-center gap-2 text-sm text-moss-green">
+      <div className="flex items-center gap-2 text-sm text-brand-ink">
         <div className="relative">
           <Wifi className="w-4 h-4" />
           <div className="absolute -top-1 -right-1 w-2 h-2 rounded-full bg-moss-green" />
@@ -42,14 +42,14 @@ export default function ConnectionStatus() {
   // Disconnected or error state
   return (
     <div className="flex items-center gap-2">
-      <div className="flex items-center gap-2 text-sm text-red-500">
+      <div className="flex items-center gap-2 text-sm text-danger-ink">
         <div className="relative">
           {status === 'error' ? (
             <AlertCircle className="w-4 h-4" />
           ) : (
             <WifiOff className="w-4 h-4" />
           )}
-          <div className="absolute -top-1 -right-1 w-2 h-2 rounded-full bg-red-500" />
+          <div className="absolute -top-1 -right-1 w-2 h-2 rounded-full bg-danger" />
         </div>
         <span className="hidden sm:inline">
           {status === 'error' ? 'Connection Error' : 'Disconnected'}
@@ -59,7 +59,7 @@ export default function ConnectionStatus() {
       {/* Retry button */}
       <button
         onClick={reconnect}
-        className="text-xs px-2 py-1 rounded bg-red-500/10 text-red-600 hover:bg-red-500/20 transition-colors"
+        className="text-xs px-2 py-1 rounded bg-danger/10 text-danger-ink hover:bg-danger/20 transition-colors"
         title={error || 'Reconnect to server'}
       >
         Retry
@@ -84,7 +84,7 @@ export function ConnectionStatusCompact() {
         return 'bg-warm-amber animate-pulse';
       case 'disconnected':
       case 'error':
-        return 'bg-red-500';
+        return 'bg-danger';
       default:
         return 'bg-stone-gray';
     }

--- a/frontend/src/components/CreateCampaignModal.tsx
+++ b/frontend/src/components/CreateCampaignModal.tsx
@@ -141,7 +141,7 @@ export default function CreateCampaignModal({
         {/* Info Box */}
         <div className="rounded-lg p-4 bg-brand/10 border border-brand/30">
           <p className="text-sm text-ink">
-            <strong className="text-brand">Note:</strong> You will be automatically assigned
+            <strong className="text-brand-ink">Note:</strong> You will be automatically assigned
             as the Dungeon Master (DM) for this campaign. You can invite players from the campaign
             settings page.
           </p>

--- a/frontend/src/components/PasswordStrengthIndicator.tsx
+++ b/frontend/src/components/PasswordStrengthIndicator.tsx
@@ -30,10 +30,10 @@ export default function PasswordStrengthIndicator({
         <span
           className={`text-xs font-medium ${
             strength.color === 'green'
-              ? 'text-green-600'
+              ? 'text-success-ink'
               : strength.color === 'yellow'
-              ? 'text-yellow-600'
-              : 'text-red-600'
+              ? 'text-warning-ink'
+              : 'text-danger-ink'
           }`}
         >
           {strength.label}
@@ -43,10 +43,10 @@ export default function PasswordStrengthIndicator({
         <div
           className={`h-1.5 rounded-full transition-all ${
             strength.color === 'green'
-              ? 'bg-green-600'
+              ? 'bg-success'
               : strength.color === 'yellow'
-              ? 'bg-yellow-600'
-              : 'bg-red-600'
+              ? 'bg-warning'
+              : 'bg-danger'
           }`}
           style={{ width: `${(strength.score / 10) * 100}%` }}
         ></div>

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -26,7 +26,7 @@ export default function ProtectedRoute({
       <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-soft-cream via-parchment to-warm-amber/20">
         <div className="glass-panel p-8 text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-moss-green mx-auto mb-4"></div>
-          <p className="text-moss-green">Loading...</p>
+          <p className="text-brand-ink">Loading...</p>
         </div>
       </div>
     );
@@ -65,7 +65,7 @@ export default function ProtectedRoute({
               </svg>
             </div>
           </div>
-          <h1 className="text-2xl font-bold text-moss-green font-heading">
+          <h1 className="text-2xl font-bold text-brand-ink font-heading">
             Access Denied
           </h1>
           <p className="text-stone-gray">

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -18,7 +18,7 @@ export default function ProtectedRoute({
   children,
   requireRole,
 }: ProtectedRouteProps) {
-  const { user, loading, authenticated } = useAuth();
+  const { user, loading, authenticated, mustChangePassword } = useAuth();
 
   // Show loading state while checking authentication
   if (loading) {
@@ -35,6 +35,12 @@ export default function ProtectedRoute({
   // Redirect to login if not authenticated
   if (!authenticated || !user) {
     return <Navigate to="/auth/login" replace />;
+  }
+
+  // Account still has to replace an admin-issued password. The server rejects
+  // every other API call until it does, so send them somewhere that works.
+  if (mustChangePassword) {
+    return <Navigate to="/auth/change-password" replace />;
   }
 
   // Check role-based access if required

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -53,14 +53,14 @@ export default function Toast({
   const getStyles = () => {
     switch (type) {
       case 'success':
-        return 'bg-green-50 border-green-200 text-green-800';
+        return 'bg-success/10 border-success/30 text-success-ink';
       case 'error':
-        return 'bg-red-50 border-red-200 text-red-800';
+        return 'bg-danger/10 border-danger/30 text-danger-ink';
       case 'warning':
-        return 'bg-yellow-50 border-yellow-200 text-yellow-800';
+        return 'bg-warning/10 border-warning/30 text-warning-ink';
       case 'info':
       default:
-        return 'bg-blue-50 border-blue-200 text-blue-800';
+        return 'bg-info/10 border-info/30 text-info-ink';
     }
   };
 

--- a/frontend/src/components/__tests__/ProtectedRoute.test.tsx
+++ b/frontend/src/components/__tests__/ProtectedRoute.test.tsx
@@ -123,4 +123,34 @@ describe('ProtectedRoute', () => {
     expect(screen.getByText(/Required role:/)).toBeInTheDocument();
     expect(screen.getByText(/Your role:/)).toBeInTheDocument();
   });
+
+  // The server refuses every other API call while this flag is set, so the app
+  // must send the user somewhere that works instead of a dead page.
+  it('redirects to the change-password page when a password change is required', () => {
+    mockUseAuth.mockReturnValue(
+      makeAuthState({
+        loading: false,
+        authenticated: true,
+        user: mockUser,
+        mustChangePassword: true,
+      })
+    );
+    renderRoute(<div>Protected Content</div>);
+    expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
+  });
+
+  it('takes precedence over the role check', () => {
+    mockUseAuth.mockReturnValue(
+      makeAuthState({
+        loading: false,
+        authenticated: true,
+        user: mockUser,
+        mustChangePassword: true,
+      })
+    );
+    renderRoute(<div>Admin Only</div>, PlatformRole.ADMIN);
+    // Redirected to set a password rather than shown an access error
+    expect(screen.queryByText('Access Denied')).not.toBeInTheDocument();
+    expect(screen.queryByText('Admin Only')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/appearance/ThemePicker.tsx
+++ b/frontend/src/components/appearance/ThemePicker.tsx
@@ -8,7 +8,7 @@
  * User.preferences).
  */
 
-import { Palette, Settings } from 'lucide-react';
+import { Palette, Settings, AlertTriangle, Check } from 'lucide-react';
 import {
   PRESET_THEMES,
   FONT_OPTIONS,
@@ -18,6 +18,7 @@ import {
   hexToRgbChannels,
   type FontOption,
 } from '../../themes';
+import { contrastRatioChannels, AA_TEXT } from '../../utils/color';
 
 export interface ThemePickerColors {
   primary: string;
@@ -95,7 +96,7 @@ export default function ThemePicker({
       <section className="glass-panel p-6 space-y-4">
         <div className="flex items-center gap-2 pb-2 border-b border-warm-gray/20">
           <Palette className="w-4 h-4 text-warm-amber" />
-          <h3 className="font-semibold text-moss-green text-sm">Color Theme</h3>
+          <h3 className="font-semibold text-brand-ink text-sm">Color Theme</h3>
         </div>
 
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
@@ -215,6 +216,7 @@ export default function ThemePicker({
                 </div>
               </div>
             ))}
+            <ContrastReport colors={customColors} />
           </div>
         )}
       </section>
@@ -223,7 +225,7 @@ export default function ThemePicker({
       <section className="glass-panel p-6 space-y-4">
         <div className="flex items-center gap-2 pb-2 border-b border-warm-gray/20">
           <Settings className="w-4 h-4 text-warm-amber" />
-          <h3 className="font-semibold text-moss-green text-sm">Font Family</h3>
+          <h3 className="font-semibold text-brand-ink text-sm">Font Family</h3>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
@@ -260,5 +262,59 @@ export default function ThemePicker({
         </div>
       </section>
     </>
+  );
+}
+
+/**
+ * Live readability check for custom colors.
+ *
+ * Preset themes are verified by themes.contrast.test.ts, but custom colors are
+ * whatever the user picks — this gives them the same feedback before they save
+ * a combination nobody can read. Uses the same contrast helper as the test, so
+ * the two can never disagree.
+ */
+function ContrastReport({ colors }: { colors: ThemePickerColors }) {
+  const derived = buildCustomThemeColors({
+    primary: hexToRgbChannels(colors.primary),
+    accent: hexToRgbChannels(colors.accent),
+    background: hexToRgbChannels(colors.background),
+    text: hexToRgbChannels(colors.text),
+  });
+
+  const checks = [
+    { label: 'Body text on background', fg: derived.ink, bg: derived.bgBase },
+    { label: 'Muted text on background', fg: derived.inkMuted, bg: derived.bgBase },
+    { label: 'Primary text on background', fg: derived.brand, bg: derived.bgBase },
+    { label: 'Button label on accent', fg: derived.accentText, bg: derived.accent },
+  ].map((check) => ({ ...check, ratio: contrastRatioChannels(check.fg, check.bg) }));
+
+  const failing = checks.filter((c) => c.ratio < AA_TEXT);
+
+  return (
+    <div className="col-span-2 sm:col-span-4 pt-3 border-t border-warm-gray/20">
+      <p className="text-xs font-medium text-charcoal mb-2">Readability</p>
+      <ul className="space-y-1">
+        {checks.map((check) => (
+          <li key={check.label} className="flex items-center gap-2 text-[11px]">
+            {check.ratio >= AA_TEXT ? (
+              <Check className="w-3 h-3 text-success-ink flex-shrink-0" aria-hidden="true" />
+            ) : (
+              <AlertTriangle className="w-3 h-3 text-warning-ink flex-shrink-0" aria-hidden="true" />
+            )}
+            <span className="text-warm-gray">{check.label}</span>
+            <span className={`font-mono ml-auto ${check.ratio >= AA_TEXT ? 'text-warm-gray' : 'text-warning-ink'}`}>
+              {check.ratio.toFixed(1)}:1
+            </span>
+          </li>
+        ))}
+      </ul>
+      {failing.length > 0 && (
+        <p className="text-[11px] text-warning-ink mt-2">
+          {failing.length === 1 ? 'One combination falls' : `${failing.length} combinations fall`} below the
+          4.5:1 minimum for readable text. CozyVTT adjusts these automatically where it can, but picking a
+          darker text color or a lighter background gives a better result.
+        </p>
+      )}
+    </div>
   );
 }

--- a/frontend/src/components/assets/AssetCard.tsx
+++ b/frontend/src/components/assets/AssetCard.tsx
@@ -66,7 +66,7 @@ function AssetCardInner({ asset, viewMode, onView, onDelete }: AssetCardProps) {
       case AssetType.MAP:
         return <MapPin className="w-8 h-8 text-warm-amber" />;
       case AssetType.TOKEN:
-        return <User className="w-8 h-8 text-moss-green" />;
+        return <User className="w-8 h-8 text-brand-ink" />;
       case AssetType.AUDIO:
         return <FileAudio className="w-8 h-8 text-spirit-purple" />;
       case AssetType.AVATAR:
@@ -144,7 +144,7 @@ function AssetCardInner({ asset, viewMode, onView, onDelete }: AssetCardProps) {
 
           {/* Info */}
           <div className="flex-1 min-w-0">
-            <h3 className="text-lg font-semibold text-moss-green truncate">
+            <h3 className="text-lg font-semibold text-brand-ink truncate">
               {asset.name}
             </h3>
             <div className="flex items-center gap-3 mt-1 text-sm text-stone-gray">
@@ -185,7 +185,7 @@ function AssetCardInner({ asset, viewMode, onView, onDelete }: AssetCardProps) {
           <div className="flex items-center gap-2">
             <button
               onClick={onView}
-              className="p-2 rounded-lg bg-moss-green/10 hover:bg-moss-green/20 text-moss-green transition-colors"
+              className="p-2 rounded-lg bg-moss-green/10 hover:bg-moss-green/20 text-brand-ink transition-colors"
               title="View details"
             >
               <Eye className="w-5 h-5" />
@@ -201,7 +201,7 @@ function AssetCardInner({ asset, viewMode, onView, onDelete }: AssetCardProps) {
               <button
                 onClick={handleDelete}
                 disabled={isDeleting}
-                className="p-2 rounded-lg bg-red-500/10 hover:bg-red-500/20 text-red-600 transition-colors disabled:opacity-50"
+                className="p-2 rounded-lg bg-danger/10 hover:bg-danger/20 text-danger-ink transition-colors disabled:opacity-50"
                 title="Delete"
               >
                 <Trash2 className="w-5 h-5" />
@@ -282,7 +282,7 @@ function AssetCardInner({ asset, viewMode, onView, onDelete }: AssetCardProps) {
               className="p-3 bg-paper-white rounded-full hover:bg-white transition-colors"
               title="View details"
             >
-              <Eye className="w-5 h-5 text-moss-green" />
+              <Eye className="w-5 h-5 text-brand-ink" />
             </button>
             <button
               onClick={handleDownload}
@@ -295,7 +295,7 @@ function AssetCardInner({ asset, viewMode, onView, onDelete }: AssetCardProps) {
               <button
                 onClick={handleDelete}
                 disabled={isDeleting}
-                className="p-3 bg-red-500/90 rounded-full hover:bg-red-600 transition-colors disabled:opacity-50"
+                className="p-3 bg-danger/90 rounded-full hover:bg-danger transition-colors disabled:opacity-50"
                 title="Delete"
               >
                 <Trash2 className="w-5 h-5 text-white" />
@@ -307,7 +307,7 @@ function AssetCardInner({ asset, viewMode, onView, onDelete }: AssetCardProps) {
 
       {/* Content */}
       <div className="p-4">
-        <h3 className="text-lg font-semibold text-moss-green truncate mb-2">
+        <h3 className="text-lg font-semibold text-brand-ink truncate mb-2">
           {asset.name}
         </h3>
 

--- a/frontend/src/components/assets/AssetDetailPanel.tsx
+++ b/frontend/src/components/assets/AssetDetailPanel.tsx
@@ -126,7 +126,7 @@ export default function AssetDetailPanel({ asset, onClose, onDelete, onUpdate }:
       case AssetType.MAP:
         return <MapPin className="w-5 h-5 text-warm-amber" />;
       case AssetType.TOKEN:
-        return <User className="w-5 h-5 text-moss-green" />;
+        return <User className="w-5 h-5 text-brand-ink" />;
       case AssetType.AUDIO:
         return <FileAudio className="w-5 h-5 text-spirit-purple" />;
       case AssetType.AVATAR:
@@ -227,7 +227,7 @@ export default function AssetDetailPanel({ asset, onClose, onDelete, onUpdate }:
             <div className="sticky top-0 z-10 bg-moss-green/10 backdrop-blur-sm border-b border-moss-green/20 p-6">
               <div className="flex items-start justify-between">
                 <div className="flex-1 min-w-0">
-                  <h2 className="text-2xl font-bold text-moss-green mb-1 truncate">
+                  <h2 className="text-2xl font-bold text-brand-ink mb-1 truncate">
                     {currentAsset.name}
                   </h2>
                   <div className="flex items-center gap-2 flex-wrap">
@@ -274,7 +274,7 @@ export default function AssetDetailPanel({ asset, onClose, onDelete, onUpdate }:
             <div className="p-6 space-y-6">
               {/* Preview */}
               <div>
-                <h3 className="text-lg font-semibold text-moss-green mb-3">Preview</h3>
+                <h3 className="text-lg font-semibold text-brand-ink mb-3">Preview</h3>
                 <div className="relative w-full rounded-lg overflow-hidden bg-moss-green/10">
                   {currentAsset.type === AssetType.AUDIO ? (
                     <div className="flex items-center justify-center h-64">
@@ -309,7 +309,7 @@ export default function AssetDetailPanel({ asset, onClose, onDelete, onUpdate }:
               {/* Description */}
               {currentAsset.description && (
                 <div>
-                  <h3 className="text-lg font-semibold text-moss-green mb-3">Description</h3>
+                  <h3 className="text-lg font-semibold text-brand-ink mb-3">Description</h3>
                   <p className="text-stone-gray whitespace-pre-wrap">{currentAsset.description}</p>
                 </div>
               )}
@@ -317,7 +317,7 @@ export default function AssetDetailPanel({ asset, onClose, onDelete, onUpdate }:
               {/* Tags */}
               {currentAsset.tags.length > 0 && (
                 <div>
-                  <h3 className="text-lg font-semibold text-moss-green mb-3">Tags</h3>
+                  <h3 className="text-lg font-semibold text-brand-ink mb-3">Tags</h3>
                   <div className="flex items-center gap-2 flex-wrap">
                     {currentAsset.tags.map((tag) => (
                       <span
@@ -335,7 +335,7 @@ export default function AssetDetailPanel({ asset, onClose, onDelete, onUpdate }:
               {/* Move to… */}
               {canMove && availableMoveScopes.length > 0 && (
                 <div>
-                  <h3 className="text-lg font-semibold text-moss-green mb-3 flex items-center gap-2">
+                  <h3 className="text-lg font-semibold text-brand-ink mb-3 flex items-center gap-2">
                     <ArrowRightLeft className="w-5 h-5" />
                     Move to…
                   </h3>
@@ -386,10 +386,10 @@ export default function AssetDetailPanel({ asset, onClose, onDelete, onUpdate }:
 
                     {/* Error / success */}
                     {moveError && (
-                      <p className="text-sm text-red-600">{moveError}</p>
+                      <p className="text-sm text-danger-ink">{moveError}</p>
                     )}
                     {moveSuccess && (
-                      <p className="flex items-center gap-1 text-sm text-moss-green">
+                      <p className="flex items-center gap-1 text-sm text-brand-ink">
                         <Check className="w-4 h-4" />
                         Asset moved successfully.
                       </p>
@@ -423,7 +423,7 @@ export default function AssetDetailPanel({ asset, onClose, onDelete, onUpdate }:
 
               {/* Metadata */}
               <div>
-                <h3 className="text-lg font-semibold text-moss-green mb-3">Metadata</h3>
+                <h3 className="text-lg font-semibold text-brand-ink mb-3">Metadata</h3>
                 <div className="space-y-3">
                   <div className="flex items-center gap-3 p-3 bg-parchment/50 border border-moss-green/20 rounded-lg">
                     <HardDrive className="w-5 h-5 text-stone-gray/60" />
@@ -471,7 +471,7 @@ export default function AssetDetailPanel({ asset, onClose, onDelete, onUpdate }:
 
               {/* Technical Details */}
               <div>
-                <h3 className="text-lg font-semibold text-moss-green mb-3">Technical Details</h3>
+                <h3 className="text-lg font-semibold text-brand-ink mb-3">Technical Details</h3>
                 <div className="p-4 bg-parchment/50 border border-moss-green/20 rounded-lg">
                   <div className="space-y-2 font-mono text-sm">
                     <div className="flex justify-between">

--- a/frontend/src/components/assets/AssetUploadModal.tsx
+++ b/frontend/src/components/assets/AssetUploadModal.tsx
@@ -293,7 +293,7 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
           <div className="space-y-6">
             {/* Locked context banner */}
             {lockedLabel && (
-              <div className="flex items-center gap-2 px-3 py-2 bg-moss-green/10 border border-moss-green/20 rounded-lg text-sm text-moss-green">
+              <div className="flex items-center gap-2 px-3 py-2 bg-moss-green/10 border border-moss-green/20 rounded-lg text-sm text-brand-ink">
                 <MapPin className="w-4 h-4 flex-shrink-0" />
                 <span>{lockedLabel}</span>
               </div>
@@ -302,7 +302,7 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
             {/* Asset Type Selection — hidden when type is pre-locked */}
             {!defaultType && (
               <div>
-                <label className="block text-sm font-medium text-moss-green mb-2">
+                <label className="block text-sm font-medium text-brand-ink mb-2">
                   Asset Type
                 </label>
                 <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
@@ -318,7 +318,7 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
                       disabled={uploading}
                       className={`p-4 rounded-lg border-2 transition-all ${
                         assetType === type
-                          ? 'border-moss-green bg-moss-green/10 text-moss-green'
+                          ? 'border-moss-green bg-moss-green/10 text-brand-ink'
                           : 'border-moss-green/20 text-stone-gray hover:border-moss-green/50'
                       } disabled:opacity-50`}
                     >
@@ -333,7 +333,7 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
             {/* Scope Selection — hidden when scope is pre-locked OR when type is AVATAR */}
             {!defaultScope && !isAvatarType && (
               <div>
-                <label className="block text-sm font-medium text-moss-green mb-2">
+                <label className="block text-sm font-medium text-brand-ink mb-2">
                   Scope
                 </label>
                 <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
@@ -343,7 +343,7 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
                     disabled={uploading}
                     className={`p-4 rounded-lg border-2 transition-all flex flex-col items-center gap-1 ${
                       assetScope === AssetScope.USER
-                        ? 'border-moss-green bg-moss-green/10 text-moss-green'
+                        ? 'border-moss-green bg-moss-green/10 text-brand-ink'
                         : 'border-moss-green/20 text-stone-gray hover:border-moss-green/50'
                     } disabled:opacity-50`}
                   >
@@ -358,7 +358,7 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
                       disabled={uploading}
                       className={`p-4 rounded-lg border-2 transition-all flex flex-col items-center gap-1 ${
                         assetScope === AssetScope.CAMPAIGN
-                          ? 'border-moss-green bg-moss-green/10 text-moss-green'
+                          ? 'border-moss-green bg-moss-green/10 text-brand-ink'
                           : 'border-moss-green/20 text-stone-gray hover:border-moss-green/50'
                       } disabled:opacity-50`}
                     >
@@ -374,7 +374,7 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
                       disabled={uploading}
                       className={`p-4 rounded-lg border-2 transition-all flex flex-col items-center gap-1 ${
                         assetScope === AssetScope.GLOBAL
-                          ? 'border-moss-green bg-moss-green/10 text-moss-green'
+                          ? 'border-moss-green bg-moss-green/10 text-brand-ink'
                           : 'border-moss-green/20 text-stone-gray hover:border-moss-green/50'
                       } disabled:opacity-50`}
                     >
@@ -392,7 +392,7 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
             {/* AVATAR auto-scope notice */}
             {isAvatarType && !defaultScope && (
               <div className="flex items-center gap-2 px-3 py-2 bg-parchment/50 border border-moss-green/20 rounded-lg text-sm text-stone-gray">
-                <User className="w-4 h-4 flex-shrink-0 text-moss-green" />
+                <User className="w-4 h-4 flex-shrink-0 text-brand-ink" />
                 <span>Avatars are always saved to your Personal library.</span>
               </div>
             )}
@@ -400,7 +400,7 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
             {/* Campaign Selection — shown only when scope is CAMPAIGN and campaign not pre-locked */}
             {!defaultCampaignId && assetScope === AssetScope.CAMPAIGN && (
               <div>
-                <label className="block text-sm font-medium text-moss-green mb-2">
+                <label className="block text-sm font-medium text-brand-ink mb-2">
                   Select Campaign
                 </label>
                 <select
@@ -428,7 +428,7 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
 
             {/* File Upload Area */}
             <div>
-              <label className="block text-sm font-medium text-moss-green mb-2">
+              <label className="block text-sm font-medium text-brand-ink mb-2">
                 File
                 <span className="ml-2 font-normal text-xs text-stone-gray/70">
                   max {formatUploadLimit(getUploadLimit(serverConfig, assetType))}
@@ -464,8 +464,8 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
 
                 {selectedFile ? (
                   <>
-                    <FileImage className="w-12 h-12 mx-auto mb-3 text-moss-green" />
-                    <p className="text-moss-green font-medium">{selectedFile.name}</p>
+                    <FileImage className="w-12 h-12 mx-auto mb-3 text-brand-ink" />
+                    <p className="text-brand-ink font-medium">{selectedFile.name}</p>
                     <p className="text-sm text-stone-gray mt-1">
                       {(selectedFile.size / (1024 * 1024)).toFixed(2)} MB
                     </p>
@@ -482,7 +482,7 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
 
             {/* Name */}
             <div>
-              <label className="block text-sm font-medium text-moss-green mb-2">Name</label>
+              <label className="block text-sm font-medium text-brand-ink mb-2">Name</label>
               <input
                 type="text"
                 value={name}
@@ -495,7 +495,7 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
 
             {/* Description */}
             <div>
-              <label className="block text-sm font-medium text-moss-green mb-2">
+              <label className="block text-sm font-medium text-brand-ink mb-2">
                 Description (Optional)
               </label>
               <textarea
@@ -510,7 +510,7 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
 
             {/* Tags */}
             <div>
-              <label className="block text-sm font-medium text-moss-green mb-2">
+              <label className="block text-sm font-medium text-brand-ink mb-2">
                 Tags (Optional)
               </label>
               <input
@@ -534,7 +534,7 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
                       <button
                         onClick={() => handleRemoveTag(tag)}
                         disabled={uploading}
-                        className="ml-1 hover:text-red-500 transition-colors disabled:opacity-50"
+                        className="ml-1 hover:text-danger-ink transition-colors disabled:opacity-50"
                       >
                         <X className="w-3 h-3" />
                       </button>
@@ -548,7 +548,7 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
             {uploading && (
               <div>
                 <div className="flex items-center justify-between mb-2">
-                  <span className="text-sm text-moss-green">Uploading...</span>
+                  <span className="text-sm text-brand-ink">Uploading...</span>
                   <span className="text-sm text-stone-gray">{uploadProgress}%</span>
                 </div>
                 <div className="w-full h-2 bg-moss-green/20 rounded-full overflow-hidden">
@@ -563,7 +563,7 @@ export default function AssetUploadModal({ isOpen, onClose, onSuccess, defaultTy
 
             {/* Error Message */}
             {error && (
-              <div role="alert" className="p-4 bg-red-500/10 border border-red-500/20 rounded-lg text-red-600 text-sm">
+              <div role="alert" className="p-4 bg-danger/10 border border-danger/20 rounded-lg text-danger-ink text-sm">
                 {error}
               </div>
             )}

--- a/frontend/src/components/campaign/AtmospherePanel.tsx
+++ b/frontend/src/components/campaign/AtmospherePanel.tsx
@@ -207,10 +207,10 @@ export default function AtmospherePanel({ isOpen, onClose }: AtmospherePanelProp
             <div className="sticky top-0 z-10 flex items-center justify-between px-6 py-4 bg-soft-cream border-b border-moss-green/20">
               <div className="flex items-center gap-3">
                 <div className="p-2 rounded-lg bg-moss-green/10">
-                  <Cloud className="w-5 h-5 text-moss-green" />
+                  <Cloud className="w-5 h-5 text-brand-ink" />
                 </div>
                 <div>
-                  <h2 className="text-lg font-bold text-moss-green">Atmosphere</h2>
+                  <h2 className="text-lg font-bold text-brand-ink">Atmosphere</h2>
                   <p className="text-xs text-warm-gray">Visual effects + ambient audio</p>
                 </div>
               </div>
@@ -228,7 +228,7 @@ export default function AtmospherePanel({ isOpen, onClose }: AtmospherePanelProp
                   Section 1: Particle Overlay
                   ============================================ */}
               <section>
-                <h3 className="text-sm font-semibold text-moss-green uppercase tracking-wide mb-3">
+                <h3 className="text-sm font-semibold text-brand-ink uppercase tracking-wide mb-3">
                   Particle Overlay
                 </h3>
 
@@ -242,14 +242,14 @@ export default function AtmospherePanel({ isOpen, onClose }: AtmospherePanelProp
                         title={opt.description}
                         className={`flex flex-col items-center gap-2 p-3 rounded-lg border-2 transition-all ${
                           isActive
-                            ? 'border-moss-green bg-moss-green/10 text-moss-green'
+                            ? 'border-moss-green bg-moss-green/10 text-brand-ink'
                             : 'border-moss-green/20 bg-parchment/50 text-stone-gray hover:border-moss-green/50 hover:bg-moss-green/5'
                         }`}
                       >
                         {opt.icon}
                         <span className="text-xs font-medium">{opt.label}</span>
                         {isActive && (
-                          <CheckCircle className="w-3 h-3 text-moss-green" />
+                          <CheckCircle className="w-3 h-3 text-brand-ink" />
                         )}
                       </button>
                     );
@@ -281,7 +281,7 @@ export default function AtmospherePanel({ isOpen, onClose }: AtmospherePanelProp
                   Section 2: Ambient Audio
                   ============================================ */}
               <section>
-                <h3 className="text-sm font-semibold text-moss-green uppercase tracking-wide mb-3">
+                <h3 className="text-sm font-semibold text-brand-ink uppercase tracking-wide mb-3">
                   Ambient Audio
                 </h3>
 
@@ -301,7 +301,7 @@ export default function AtmospherePanel({ isOpen, onClose }: AtmospherePanelProp
                       ))}
                     </div>
                     <div className="flex-1 min-w-0">
-                      <p className="text-xs font-semibold text-moss-green">Now Playing</p>
+                      <p className="text-xs font-semibold text-brand-ink">Now Playing</p>
                       <p className="text-xs text-stone-gray truncate">
                         {audioAssets.find((a) => a.id === activeAtmosphereAudio.assetId)?.name ?? 'Audio Track'}
                       </p>
@@ -309,7 +309,7 @@ export default function AtmospherePanel({ isOpen, onClose }: AtmospherePanelProp
                     <button
                       onClick={() => handleAudioSelect(null)}
                       title="Stop audio"
-                      className="p-1.5 rounded-lg text-red-500 hover:bg-red-50 transition-colors flex-shrink-0"
+                      className="p-1.5 rounded-lg text-danger-ink hover:bg-danger/10 transition-colors flex-shrink-0"
                     >
                       <StopCircle className="w-4 h-4" />
                     </button>
@@ -324,7 +324,7 @@ export default function AtmospherePanel({ isOpen, onClose }: AtmospherePanelProp
                       <button
                         onClick={handleMuteToggle}
                         title={isMuted ? 'Unmute' : 'Mute'}
-                        className="text-stone-gray hover:text-moss-green transition-colors flex-shrink-0"
+                        className="text-stone-gray hover:text-brand-ink transition-colors flex-shrink-0"
                       >
                         {isMuted || volume === 0
                           ? <VolumeX className="w-4 h-4" />
@@ -375,7 +375,7 @@ export default function AtmospherePanel({ isOpen, onClose }: AtmospherePanelProp
                   )}
 
                   {assetError && (
-                    <p className="text-sm text-red-600 py-2">{assetError}</p>
+                    <p className="text-sm text-danger-ink py-2">{assetError}</p>
                   )}
 
                   {!loadingAssets && !assetError && audioAssets.length === 0 && (
@@ -407,12 +407,12 @@ export default function AtmospherePanel({ isOpen, onClose }: AtmospherePanelProp
                           >
                             <div className={`p-1.5 rounded ${isPlaying ? 'bg-moss-green/20' : 'bg-stone-gray/10'}`}>
                               {isPlaying
-                                ? <StopCircle className="w-4 h-4 text-moss-green" />
+                                ? <StopCircle className="w-4 h-4 text-brand-ink" />
                                 : <Play className="w-4 h-4 text-stone-gray" />
                               }
                             </div>
                             <div className="flex-1 min-w-0">
-                              <p className={`text-sm font-medium truncate ${isPlaying ? 'text-moss-green' : 'text-stone-gray'}`}>
+                              <p className={`text-sm font-medium truncate ${isPlaying ? 'text-brand-ink' : 'text-stone-gray'}`}>
                                 {asset.name}
                               </p>
                               <p className="text-xs text-warm-gray">
@@ -421,7 +421,7 @@ export default function AtmospherePanel({ isOpen, onClose }: AtmospherePanelProp
                               </p>
                             </div>
                             {isPlaying && (
-                              <CheckCircle className="w-4 h-4 text-moss-green flex-shrink-0" />
+                              <CheckCircle className="w-4 h-4 text-brand-ink flex-shrink-0" />
                             )}
                           </button>
                         );

--- a/frontend/src/components/campaign/CampaignImportDialog.tsx
+++ b/frontend/src/components/campaign/CampaignImportDialog.tsx
@@ -144,8 +144,8 @@ export default function CampaignImportDialog({
           {/* Header */}
           <div className="bg-moss-green/10 border-b border-moss-green/20 px-6 py-4 flex items-center justify-between">
             <div className="flex items-center gap-3">
-              <FileArchive className="w-5 h-5 text-moss-green" />
-              <h2 className="text-lg font-bold text-moss-green">Import Campaign</h2>
+              <FileArchive className="w-5 h-5 text-brand-ink" />
+              <h2 className="text-lg font-bold text-brand-ink">Import Campaign</h2>
             </div>
             <button
               onClick={handleClose}
@@ -170,14 +170,14 @@ export default function CampaignImportDialog({
                 >
                   {loading ? (
                     <div className="flex flex-col items-center gap-3">
-                      <Loader2 className="w-10 h-10 text-moss-green animate-spin" />
+                      <Loader2 className="w-10 h-10 text-brand-ink animate-spin" />
                       <p className="text-sm text-stone-gray">Reading archive...</p>
                     </div>
                   ) : (
                     <>
-                      <Upload className="w-10 h-10 text-moss-green/50 mx-auto mb-3" />
+                      <Upload className="w-10 h-10 text-brand-ink/50 mx-auto mb-3" />
                       <p className="text-sm font-medium text-stone-gray mb-1">
-                        Drop a <span className="font-mono text-moss-green">.cozyvtt</span> file here
+                        Drop a <span className="font-mono text-brand-ink">.cozyvtt</span> file here
                       </p>
                       <p className="text-xs text-warm-gray">or click to browse</p>
                     </>
@@ -280,7 +280,7 @@ export default function CampaignImportDialog({
             {/* ── IMPORTING STEP ── */}
             {step === 'importing' && (
               <div className="text-center py-8">
-                <Loader2 className="w-12 h-12 text-moss-green animate-spin mx-auto mb-4" />
+                <Loader2 className="w-12 h-12 text-brand-ink animate-spin mx-auto mb-4" />
                 <p className="text-sm font-medium text-stone-gray mb-1">Importing campaign...</p>
                 <p className="text-xs text-warm-gray">This may take a moment for large archives.</p>
               </div>
@@ -289,9 +289,9 @@ export default function CampaignImportDialog({
             {/* ── DONE STEP ── */}
             {step === 'done' && result && (
               <div className="text-center py-6 space-y-4">
-                <CheckCircle2 className="w-12 h-12 text-moss-green mx-auto" />
+                <CheckCircle2 className="w-12 h-12 text-brand-ink mx-auto" />
                 <div>
-                  <p className="text-lg font-bold text-moss-green mb-1">Import Complete!</p>
+                  <p className="text-lg font-bold text-brand-ink mb-1">Import Complete!</p>
                   <p className="text-sm text-stone-gray">
                     <span className="font-semibold">{result.campaignName}</span> is ready.
                   </p>
@@ -328,9 +328,9 @@ export default function CampaignImportDialog({
             {/* ── ERROR STEP ── */}
             {step === 'error' && (
               <div className="text-center py-6 space-y-4">
-                <AlertCircle className="w-12 h-12 text-red-500 mx-auto" />
+                <AlertCircle className="w-12 h-12 text-danger-ink mx-auto" />
                 <div>
-                  <p className="text-lg font-bold text-red-600 mb-1">Import Failed</p>
+                  <p className="text-lg font-bold text-danger-ink mb-1">Import Failed</p>
                   <p className="text-sm text-stone-gray">{errorMessage}</p>
                 </div>
                 <div className="flex items-center gap-3 pt-2">
@@ -354,7 +354,7 @@ export default function CampaignImportDialog({
 function StatCard({ icon, label, value }: { icon: React.ReactNode; label: string; value: string | number }) {
   return (
     <div className="flex items-center gap-2 p-3 rounded-lg bg-parchment/50 border border-moss-green/10">
-      <span className="text-moss-green">{icon}</span>
+      <span className="text-brand-ink">{icon}</span>
       <div>
         <p className="text-xs text-warm-gray">{label}</p>
         <p className="text-sm font-semibold text-stone-gray">{value}</p>

--- a/frontend/src/components/campaign/CampaignInfo.tsx
+++ b/frontend/src/components/campaign/CampaignInfo.tsx
@@ -35,7 +35,7 @@ export default function CampaignInfo() {
       },
       ACTIVE: {
         label: 'Active',
-        class: 'bg-moss-green/20 text-moss-green border-moss-green/30',
+        class: 'bg-moss-green/20 text-brand-ink border-moss-green/30',
       },
       PAUSED: {
         label: 'Paused',
@@ -68,15 +68,15 @@ export default function CampaignInfo() {
     <div className="glass-panel p-4 space-y-4">
       {/* Header */}
       <div className="flex items-center gap-2 pb-2 border-b border-moss-green/20">
-        <Info className="w-5 h-5 text-moss-green" />
-        <h3 className="text-lg font-semibold text-moss-green">
+        <Info className="w-5 h-5 text-brand-ink" />
+        <h3 className="text-lg font-semibold text-brand-ink">
           Campaign Info
         </h3>
       </div>
 
       {/* Campaign Name */}
       <div>
-        <h2 className="text-xl font-bold text-moss-green mb-1">
+        <h2 className="text-xl font-bold text-brand-ink mb-1">
           {campaign.name}
         </h2>
         {campaign.description && (
@@ -99,7 +99,7 @@ export default function CampaignInfo() {
       {/* Details */}
       <div className="space-y-2 text-sm">
         <div className="flex items-center gap-2 text-stone-gray">
-          <Crown className="w-4 h-4 text-moss-green" />
+          <Crown className="w-4 h-4 text-brand-ink" />
           <span className="text-warm-gray">DM:</span>
           <span className="text-stone-gray font-medium">{ownerName}</span>
         </div>
@@ -126,7 +126,7 @@ export default function CampaignInfo() {
         <div className="pt-2 border-t border-moss-green/20">
           <button
             onClick={() => setShowInviteModal(true)}
-            className="flex items-center gap-2 px-3 py-2 w-full rounded-lg bg-moss-green/10 text-moss-green hover:bg-moss-green/20 transition-colors text-sm font-medium"
+            className="flex items-center gap-2 px-3 py-2 w-full rounded-lg bg-moss-green/10 text-brand-ink hover:bg-moss-green/20 transition-colors text-sm font-medium"
           >
             <UserPlus className="w-4 h-4" />
             Invite Player
@@ -141,7 +141,7 @@ export default function CampaignInfo() {
           <div
             className={`inline-block ml-2 px-2.5 py-1 rounded-full border text-xs font-medium ${
               userRole === 'DM'
-                ? 'bg-moss-green/20 text-moss-green border-moss-green/40'
+                ? 'bg-moss-green/20 text-brand-ink border-moss-green/40'
                 : 'bg-spirit-purple/20 text-spirit-purple border-spirit-purple/40'
             }`}
           >

--- a/frontend/src/components/campaign/CampaignRoster.tsx
+++ b/frontend/src/components/campaign/CampaignRoster.tsx
@@ -200,13 +200,13 @@ export default function CampaignRoster() {
   const getSystemBadgeColor = (gameSystem: GameSystem | null) => {
     switch (gameSystem) {
       case 'DND_5E':
-        return 'bg-red-100 text-red-700';
+        return 'bg-danger/10 text-danger-ink';
       case 'PATHFINDER_2E':
-        return 'bg-blue-100 text-blue-700';
+        return 'bg-info/10 text-info-ink';
       case 'SHADOWRUN_6E':
-        return 'bg-purple-100 text-purple-700';
+        return 'bg-spirit/10 text-spirit-ink';
       case 'CALL_OF_CTHULHU_7E':
-        return 'bg-green-100 text-green-700';
+        return 'bg-success/10 text-success-ink';
       default:
         return 'bg-ink/10 text-ink';
     }
@@ -240,8 +240,8 @@ export default function CampaignRoster() {
     <div className="glass-panel p-4 space-y-4">
       {/* Header */}
       <div className="flex items-center gap-2 pb-2 border-b border-moss-green/20">
-        <Users className="w-5 h-5 text-moss-green" />
-        <h3 className="text-lg font-semibold text-moss-green">Campaign Roster</h3>
+        <Users className="w-5 h-5 text-brand-ink" />
+        <h3 className="text-lg font-semibold text-brand-ink">Campaign Roster</h3>
       </div>
 
       {loading ? (
@@ -257,7 +257,7 @@ export default function CampaignRoster() {
           {/* DM Section */}
           {groupedRoster.DM.length > 0 && (
             <div>
-              <h4 className="text-xs font-semibold text-moss-green/60 uppercase tracking-wider mb-2">
+              <h4 className="text-xs font-semibold text-brand-ink/60 uppercase tracking-wider mb-2">
                 Dungeon Master
               </h4>
               <div className="space-y-2">
@@ -271,7 +271,7 @@ export default function CampaignRoster() {
           {/* Players Section */}
           {groupedRoster.PLAYER.length > 0 && (
             <div>
-              <h4 className="text-xs font-semibold text-moss-green/60 uppercase tracking-wider mb-2">
+              <h4 className="text-xs font-semibold text-brand-ink/60 uppercase tracking-wider mb-2">
                 Players
               </h4>
               <div className="space-y-2">
@@ -285,7 +285,7 @@ export default function CampaignRoster() {
           {/* Spectators Section */}
           {groupedRoster.SPECTATOR.length > 0 && (
             <div>
-              <h4 className="text-xs font-semibold text-moss-green/60 uppercase tracking-wider mb-2">
+              <h4 className="text-xs font-semibold text-brand-ink/60 uppercase tracking-wider mb-2">
                 Spectators
               </h4>
               <div className="space-y-2">
@@ -347,7 +347,7 @@ export default function CampaignRoster() {
               label: 'Remove from Campaign',
               onClick: handleRemoveFromCampaign,
               visible: user.id === contextMenu.characterUserId || userMembership.role === 'DM',
-              className: 'text-red-600 hover:bg-red-50',
+              className: 'text-danger-ink hover:bg-danger/10',
             },
           ]}
           onClose={handleCloseContextMenu}
@@ -418,7 +418,7 @@ function MemberCard({ member, getRoleIcon, getSystemBadgeColor, getSystemShortNa
         >
           <RoleIcon
             className={`w-4 h-4 ${
-              member.role === 'DM' ? 'text-moss-green' : 'text-spirit-purple'
+              member.role === 'DM' ? 'text-brand-ink' : 'text-spirit-purple'
             }`}
           />
         </div>
@@ -471,7 +471,7 @@ function MemberCard({ member, getRoleIcon, getSystemBadgeColor, getSystemShortNa
                 />
               ) : (
                 <div className="w-6 h-6 rounded-full bg-moss-green/10 border border-moss-green/20 flex items-center justify-center">
-                  <span className="text-xs text-moss-green font-semibold">
+                  <span className="text-xs text-brand-ink font-semibold">
                     {character.name.charAt(0).toUpperCase()}
                   </span>
                 </div>
@@ -500,10 +500,10 @@ function MemberCard({ member, getRoleIcon, getSystemBadgeColor, getSystemShortNa
               const canAdjust = isDM || character.userId === currentUserId;
               if (!hp || hp.max === 0) return null;
               const pct = Math.max(0, Math.min(1, hp.current / hp.max));
-              const barColor = pct >= 0.75 ? 'bg-green-500'
+              const barColor = pct >= 0.75 ? 'bg-success'
                             : pct >= 0.50 ? 'bg-lime-500'
-                            : pct >= 0.25 ? 'bg-amber-500'
-                            :               'bg-red-500';
+                            : pct >= 0.25 ? 'bg-warning'
+                            :               'bg-danger';
               return (
                 <div className="mt-1 space-y-1" onClick={(e) => e.stopPropagation()}>
                   {/* HP progress bar */}
@@ -514,7 +514,7 @@ function MemberCard({ member, getRoleIcon, getSystemBadgeColor, getSystemShortNa
                     />
                     {hp.temp > 0 && (
                       <div
-                        className="h-full rounded-full bg-blue-300/75 -mt-1.5 ml-auto"
+                        className="h-full rounded-full bg-info/75 -mt-1.5 ml-auto"
                         style={{ width: `${Math.min(1, hp.temp / hp.max) * 100}%` }}
                       />
                     )}
@@ -524,26 +524,26 @@ function MemberCard({ member, getRoleIcon, getSystemBadgeColor, getSystemShortNa
                     <div className="flex items-center gap-1">
                       <button
                         onClick={() => onHpDelta(character.id, -5)}
-                        className="flex items-center justify-center w-5 h-5 rounded text-xs font-bold text-stone-gray bg-black/10 hover:bg-red-100 hover:text-red-600 transition-colors"
+                        className="flex items-center justify-center w-5 h-5 rounded text-xs font-bold text-stone-gray bg-black/10 hover:bg-danger/10 hover:text-danger-ink transition-colors"
                         title="−5 HP"
                       >−5</button>
                       <button
                         onClick={() => onHpDelta(character.id, -1)}
-                        className="flex items-center justify-center w-5 h-5 rounded text-stone-gray bg-black/10 hover:bg-red-100 hover:text-red-600 transition-colors"
+                        className="flex items-center justify-center w-5 h-5 rounded text-stone-gray bg-black/10 hover:bg-danger/10 hover:text-danger-ink transition-colors"
                         title="−1 HP"
                       ><Minus className="w-3 h-3" /></button>
                       <span className="flex-1 text-center text-xs font-semibold text-stone-gray">
                         {hp.current}<span className="font-normal text-warm-gray">/{hp.max}</span>
-                        {hp.temp > 0 && <span className="text-blue-500 ml-0.5">+{hp.temp}</span>}
+                        {hp.temp > 0 && <span className="text-info-ink ml-0.5">+{hp.temp}</span>}
                       </span>
                       <button
                         onClick={() => onHpDelta(character.id, 1)}
-                        className="flex items-center justify-center w-5 h-5 rounded text-stone-gray bg-black/10 hover:bg-green-100 hover:text-green-600 transition-colors"
+                        className="flex items-center justify-center w-5 h-5 rounded text-stone-gray bg-black/10 hover:bg-success/10 hover:text-success-ink transition-colors"
                         title="+1 HP"
                       ><Plus className="w-3 h-3" /></button>
                       <button
                         onClick={() => onHpDelta(character.id, 5)}
-                        className="flex items-center justify-center w-5 h-5 rounded text-xs font-bold text-stone-gray bg-black/10 hover:bg-green-100 hover:text-green-600 transition-colors"
+                        className="flex items-center justify-center w-5 h-5 rounded text-xs font-bold text-stone-gray bg-black/10 hover:bg-success/10 hover:text-success-ink transition-colors"
                         title="+5 HP"
                       >+5</button>
                     </div>
@@ -552,7 +552,7 @@ function MemberCard({ member, getRoleIcon, getSystemBadgeColor, getSystemShortNa
                   {!canAdjust && (
                     <p className="text-center text-xs font-semibold text-stone-gray">
                       {hp.current}<span className="font-normal text-warm-gray">/{hp.max}</span>
-                      {hp.temp > 0 && <span className="text-blue-500 ml-0.5">+{hp.temp}</span>}
+                      {hp.temp > 0 && <span className="text-info-ink ml-0.5">+{hp.temp}</span>}
                     </p>
                   )}
                 </div>

--- a/frontend/src/components/campaign/CampaignSettingsModal.tsx
+++ b/frontend/src/components/campaign/CampaignSettingsModal.tsx
@@ -216,9 +216,9 @@ export default function CampaignSettingsModal({
               <div className="sticky top-0 z-10 bg-moss-green/10 backdrop-blur-sm border-b border-moss-green/20 px-6 py-4 flex-shrink-0">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3">
-                    <Settings className="w-6 h-6 text-moss-green" />
+                    <Settings className="w-6 h-6 text-brand-ink" />
                     <div>
-                      <h2 className="text-xl font-bold text-moss-green">Campaign Settings</h2>
+                      <h2 className="text-xl font-bold text-brand-ink">Campaign Settings</h2>
                       <p className="text-xs text-stone-gray truncate max-w-[220px]">{campaign.name}</p>
                     </div>
                   </div>
@@ -247,8 +247,8 @@ export default function CampaignSettingsModal({
                       className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${
                         activeTab === tab.id
                           ? tab.id === 'danger'
-                            ? 'bg-red-500/10 text-red-600 border border-red-500/20'
-                            : 'bg-moss-green/15 text-moss-green border border-moss-green/20'
+                            ? 'bg-danger/10 text-danger-ink border border-danger/20'
+                            : 'bg-moss-green/15 text-brand-ink border border-moss-green/20'
                           : 'text-stone-gray hover:bg-warm-gray/10'
                       }`}
                     >
@@ -269,7 +269,7 @@ export default function CampaignSettingsModal({
                         htmlFor="cs-name"
                         className="block text-sm font-semibold text-stone-gray mb-1.5"
                       >
-                        Campaign Name <span className="text-red-500">*</span>
+                        Campaign Name <span className="text-danger-ink">*</span>
                       </label>
                       <input
                         id="cs-name"
@@ -327,7 +327,7 @@ export default function CampaignSettingsModal({
                     {/* ── Export ── */}
                     <div className="pt-4 mt-4 border-t border-moss-green/15 space-y-3">
                       <div className="flex items-center gap-2 text-sm font-semibold text-stone-gray">
-                        <Download className="w-4 h-4 text-moss-green" />
+                        <Download className="w-4 h-4 text-brand-ink" />
                         Export Campaign
                       </div>
                       <p className="text-xs text-warm-gray">
@@ -383,7 +383,7 @@ export default function CampaignSettingsModal({
                 {activeTab === 'chat' && (
                   <div className="space-y-5">
                     <div className="flex items-start gap-3 p-4 rounded-lg bg-moss-green/5 border border-moss-green/15">
-                      <MessageCircle className="w-5 h-5 text-moss-green flex-shrink-0 mt-0.5" />
+                      <MessageCircle className="w-5 h-5 text-brand-ink flex-shrink-0 mt-0.5" />
                       <p className="text-sm text-stone-gray">
                         A message cooldown prevents players from sending messages too quickly.
                         When enabled, each player must wait the configured number of seconds
@@ -502,7 +502,7 @@ export default function CampaignSettingsModal({
                           >
                             <div className="flex items-center gap-3 min-w-0">
                               <div className="w-8 h-8 rounded-full bg-moss-green/15 flex items-center justify-center flex-shrink-0">
-                                <span className="text-sm font-bold text-moss-green uppercase">
+                                <span className="text-sm font-bold text-brand-ink uppercase">
                                   {(membership.user?.displayName ?? '?')[0]}
                                 </span>
                               </div>
@@ -527,7 +527,7 @@ export default function CampaignSettingsModal({
                                     ? 'bg-spirit-purple/10 text-spirit-purple border-spirit-purple/20'
                                     : membership.role === 'SPECTATOR'
                                     ? 'bg-stone-gray/10 text-stone-gray border-stone-gray/20'
-                                    : 'bg-moss-green/10 text-moss-green border-moss-green/20'
+                                    : 'bg-moss-green/10 text-brand-ink border-moss-green/20'
                                 }`}
                               >
                                 {isDm ? (
@@ -546,7 +546,7 @@ export default function CampaignSettingsModal({
                                   type="button"
                                   onClick={() => handleRemoveMemberClick(membership)}
                                   disabled={isRemoving}
-                                  className="p-1.5 rounded-lg text-red-400 hover:text-red-600 hover:bg-red-50 transition-colors disabled:opacity-40"
+                                  className="p-1.5 rounded-lg text-danger-ink hover:text-danger-ink hover:bg-danger/10 transition-colors disabled:opacity-40"
                                   aria-label={`Remove ${membership.user?.displayName} from campaign`}
                                 >
                                   {isRemoving ? (
@@ -567,17 +567,17 @@ export default function CampaignSettingsModal({
                 {/* ════ DANGER ZONE TAB ════ */}
                 {activeTab === 'danger' && (
                   <div className="space-y-4">
-                    <div className="p-4 rounded-lg bg-red-50 border border-red-200">
+                    <div className="p-4 rounded-lg bg-danger/10 border border-danger/30">
                       <div className="flex items-start gap-3 mb-4">
-                        <AlertTriangle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
+                        <AlertTriangle className="w-5 h-5 text-danger-ink flex-shrink-0 mt-0.5" />
                         <div>
-                          <h3 className="text-sm font-bold text-red-800 mb-1">Delete Campaign</h3>
-                          <p className="text-sm text-red-700">
+                          <h3 className="text-sm font-bold text-danger-ink mb-1">Delete Campaign</h3>
+                          <p className="text-sm text-danger-ink">
                             Permanently deletes this campaign and all associated maps, tokens, chat
                             history, and session records. Characters and uploaded assets are{' '}
                             <strong>not</strong> deleted — they remain in your library.
                           </p>
-                          <p className="text-sm text-red-700 mt-2">
+                          <p className="text-sm text-danger-ink mt-2">
                             This action <strong>cannot be undone</strong>.
                           </p>
                         </div>
@@ -587,16 +587,16 @@ export default function CampaignSettingsModal({
                         <div>
                           <label
                             htmlFor="cs-delete-confirm"
-                            className="block text-sm font-semibold text-red-800 mb-1.5"
+                            className="block text-sm font-semibold text-danger-ink mb-1.5"
                           >
-                            Type <span className="font-mono bg-red-100 px-1 rounded">{campaign.name}</span> to confirm:
+                            Type <span className="font-mono bg-danger/10 px-1 rounded">{campaign.name}</span> to confirm:
                           </label>
                           <input
                             id="cs-delete-confirm"
                             type="text"
                             value={deleteConfirmName}
                             onChange={(e) => setDeleteConfirmName(e.target.value)}
-                            className="input-cozy w-full border-red-300 focus:border-red-500 focus:ring-red-500/20"
+                            className="input-cozy w-full border-danger/30 focus:border-danger/60 focus:ring-danger/20"
                             placeholder={campaign.name}
                             autoComplete="off"
                           />

--- a/frontend/src/components/campaign/CharacterRollPicker.tsx
+++ b/frontend/src/components/campaign/CharacterRollPicker.tsx
@@ -64,7 +64,7 @@ const Section: React.FC<SectionProps> = ({ title, rolls, mode: _mode, onRoll }) 
           onClick={() => onRoll(opt)}
           className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-stone-gray hover:bg-moss-green/10 transition-colors text-left"
         >
-          <Dices className="w-3 h-3 text-moss-green flex-shrink-0" />
+          <Dices className="w-3 h-3 text-brand-ink flex-shrink-0" />
           <span className="flex-1">{opt.label}</span>
         </button>
       ))}
@@ -201,7 +201,7 @@ export default function CharacterRollPicker({
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-2 bg-moss-green/10 border-b border-moss-green/20">
         <div className="flex items-center gap-2">
-          <Dices className="w-4 h-4 text-moss-green" />
+          <Dices className="w-4 h-4 text-brand-ink" />
           <span className="text-sm font-semibold text-stone-gray truncate">
             Roll for {characterName}
           </span>
@@ -220,7 +220,7 @@ export default function CharacterRollPicker({
               onClick={() => setModeOpen((o) => !o)}
               className="w-full flex items-center justify-between px-2 py-1.5 rounded border border-moss-green/30 bg-paper/60 text-sm text-ink-secondary hover:bg-paper/80 transition-colors"
             >
-              <span className={mode !== 'normal' ? 'text-amber-600 font-medium' : ''}>
+              <span className={mode !== 'normal' ? 'text-warning-ink font-medium' : ''}>
                 {modeLabels[mode]}
               </span>
               <ChevronDown className="w-3.5 h-3.5 text-warm-gray" />
@@ -232,7 +232,7 @@ export default function CharacterRollPicker({
                     key={m}
                     onClick={() => { setMode(m); setModeOpen(false); }}
                     className={`w-full text-left px-3 py-2 text-sm hover:bg-moss-green/10 transition-colors first:rounded-t-lg last:rounded-b-lg ${
-                      mode === m ? 'font-semibold text-moss-green' : 'text-stone-gray'
+                      mode === m ? 'font-semibold text-brand-ink' : 'text-stone-gray'
                     }`}
                   >
                     {modeLabels[m]}
@@ -253,7 +253,7 @@ export default function CharacterRollPicker({
         )}
 
         {error && (
-          <div className="px-3 py-4 text-sm text-red-600 text-center">{error}</div>
+          <div className="px-3 py-4 text-sm text-danger-ink text-center">{error}</div>
         )}
 
         {!loading && !error && !hasAnyRolls && (

--- a/frontend/src/components/campaign/ChatMessage.tsx
+++ b/frontend/src/components/campaign/ChatMessage.tsx
@@ -54,27 +54,27 @@ function getMessageStyle(type: MessageType): { bg: string; textColor: string; bo
   switch (type) {
     case 'DM':
       return {
-        bg: 'bg-amber-50/30',
-        textColor: 'text-amber-900',
-        borderColor: 'border-amber-200',
+        bg: 'bg-warning/10',
+        textColor: 'text-warning-ink',
+        borderColor: 'border-warning/30',
       };
     case 'SYSTEM':
       return {
         bg: 'bg-moss-green/10',
-        textColor: 'text-moss-green',
+        textColor: 'text-brand-ink',
         borderColor: 'border-moss-green/20',
       };
     case 'DICE_ROLL':
       return {
-        bg: 'bg-blue-50/30',
-        textColor: 'text-blue-900',
-        borderColor: 'border-blue-200',
+        bg: 'bg-info/10',
+        textColor: 'text-info-ink',
+        borderColor: 'border-info/30',
       };
     case 'CHARACTER_ACTION':
       return {
-        bg: 'bg-purple-50/30',
-        textColor: 'text-purple-900',
-        borderColor: 'border-purple-200',
+        bg: 'bg-spirit/10',
+        textColor: 'text-spirit-ink',
+        borderColor: 'border-spirit/30',
       };
     default: // PLAYER
       return {
@@ -104,18 +104,18 @@ function ChatMessageInner({ message, isCurrentUser = false, isPending = false }:
       {/* Message Header */}
       <div className="flex items-center gap-2 mb-1">
         {/* Icon for special message types */}
-        {isSystem && <Bot className="w-3.5 h-3.5 text-moss-green" />}
-        {isDM && <Shield className="w-3.5 h-3.5 text-amber-600" />}
+        {isSystem && <Bot className="w-3.5 h-3.5 text-brand-ink" />}
+        {isDM && <Shield className="w-3.5 h-3.5 text-warning-ink" />}
 
         {/* Username */}
         <span
           className={`text-xs font-semibold ${
             isDM
-              ? 'text-amber-700'
+              ? 'text-warning-ink'
               : isSystem
-              ? 'text-moss-green'
+              ? 'text-brand-ink'
               : isCurrentUser
-              ? 'text-moss-green'
+              ? 'text-brand-ink'
               : 'text-stone-gray'
           }`}
         >

--- a/frontend/src/components/campaign/ChatPanel.tsx
+++ b/frontend/src/components/campaign/ChatPanel.tsx
@@ -402,7 +402,7 @@ export default function ChatPanel() {
       <div className="glass-panel h-full flex flex-col">
         {/* Header skeleton */}
         <div className="flex items-center gap-2 p-4 border-b border-moss-green/20">
-          <MessageCircle className="w-5 h-5 text-moss-green/40" />
+          <MessageCircle className="w-5 h-5 text-brand-ink/40" />
           <div className="h-5 w-10 bg-moss-green/15 rounded animate-pulse" />
         </div>
         {/* Message skeletons */}
@@ -425,8 +425,8 @@ export default function ChatPanel() {
     <div className="glass-panel h-full flex flex-col">
       {/* Chat Header */}
       <div className="flex items-center gap-2 p-4 border-b border-moss-green/20">
-        <MessageCircle className="w-5 h-5 text-moss-green" />
-        <h3 className="text-lg font-semibold text-moss-green">Chat</h3>
+        <MessageCircle className="w-5 h-5 text-brand-ink" />
+        <h3 className="text-lg font-semibold text-brand-ink">Chat</h3>
         {messages.length > 0 && (
           <span className="text-xs text-stone-gray/70 ml-auto">
             {messages.length} {messages.length === 1 ? 'message' : 'messages'}
@@ -436,9 +436,9 @@ export default function ChatPanel() {
 
       {/* Error Display */}
       {error && (
-        <div className="mx-4 mt-4 p-3 bg-red-50 border border-red-200 rounded-lg flex items-center gap-2">
-          <AlertCircle className="w-4 h-4 text-red-600 flex-shrink-0" />
-          <p className="text-sm text-red-800">{error}</p>
+        <div className="mx-4 mt-4 p-3 bg-danger/10 border border-danger/30 rounded-lg flex items-center gap-2">
+          <AlertCircle className="w-4 h-4 text-danger-ink flex-shrink-0" />
+          <p className="text-sm text-danger-ink">{error}</p>
         </div>
       )}
 
@@ -475,7 +475,7 @@ export default function ChatPanel() {
         {/* Messages List */}
         {messages.length === 0 ? (
           <div className="text-center py-8">
-            <MessageCircle className="w-12 h-12 text-moss-green/30 mx-auto mb-3" />
+            <MessageCircle className="w-12 h-12 text-brand-ink/30 mx-auto mb-3" />
             <p className="text-sm text-warm-gray mb-2">No messages yet</p>
             <p className="text-xs text-stone-gray/70">
               Start a conversation with your party
@@ -527,7 +527,7 @@ export default function ChatPanel() {
 
           {/* Rate Limiting Feedback */}
           {!canSend && cooldownSeconds > 0 && (
-            <p className="text-xs text-amber-700 text-center">
+            <p className="text-xs text-warning-ink text-center">
               Wait {cooldownSeconds}s before sending another message
             </p>
           )}

--- a/frontend/src/components/campaign/ConfigureVibeModal.tsx
+++ b/frontend/src/components/campaign/ConfigureVibeModal.tsx
@@ -98,7 +98,7 @@ function PeriodEditor({ period, index, canDelete, onChange, onDelete }: PeriodEd
           onClick={() => onDelete(index)}
           disabled={!canDelete}
           title={canDelete ? 'Remove this period' : 'Cannot remove the only period'}
-          className="mt-5 p-2 rounded-lg text-red-500 hover:bg-red-50 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+          className="mt-5 p-2 rounded-lg text-danger-ink hover:bg-danger/10 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
         >
           <Trash2 className="w-4 h-4" />
         </button>
@@ -211,7 +211,7 @@ function PeriodEditor({ period, index, canDelete, onChange, onDelete }: PeriodEd
         <div className="relative h-16 rounded-lg overflow-hidden ring-1 ring-moss-green/20">
           {/* Simulated map background */}
           <div
-            className="absolute inset-0 bg-gradient-to-br from-green-800 via-green-600 to-yellow-700"
+            className="absolute inset-0 bg-gradient-to-br from-success via-success to-warning"
             style={{ filter: period.filter || undefined }}
           />
           {/* Hue overlay */}
@@ -379,7 +379,7 @@ export default function ConfigureVibeModal({ onClose }: ConfigureVibeModalProps)
           {periods.length < 20 && (
             <button
               onClick={handleAddPeriod}
-              className="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-lg border-2 border-dashed border-moss-green/30 text-moss-green hover:border-moss-green/60 hover:bg-moss-green/5 transition-colors mb-6"
+              className="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-lg border-2 border-dashed border-moss-green/30 text-brand-ink hover:border-moss-green/60 hover:bg-moss-green/5 transition-colors mb-6"
             >
               <Plus className="w-4 h-4" />
               Add Period

--- a/frontend/src/components/campaign/CreateMapModal.tsx
+++ b/frontend/src/components/campaign/CreateMapModal.tsx
@@ -80,14 +80,14 @@ function AssetPicker({
       <div className="flex items-center justify-between">
         <label className="block text-sm font-medium text-stone-gray">
           {label}
-          {required && <span className="text-red-500 ml-1">*</span>}
+          {required && <span className="text-danger-ink ml-1">*</span>}
         </label>
         <div className="flex gap-2">
           {selectedAssetId && (
             <button
               type="button"
               onClick={() => onSelect(null)}
-              className="text-xs text-red-500 hover:text-red-700"
+              className="text-xs text-danger-ink hover:text-danger-ink"
             >
               Clear
             </button>
@@ -129,10 +129,10 @@ function AssetPicker({
             className="w-12 h-12 object-cover rounded"
             onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
           />
-          <span className="text-sm text-moss-green font-medium truncate flex-1">
+          <span className="text-sm text-brand-ink font-medium truncate flex-1">
             {selectedAsset.name}
           </span>
-          <Check className="w-4 h-4 text-moss-green flex-shrink-0" />
+          <Check className="w-4 h-4 text-brand-ink flex-shrink-0" />
         </div>
       )}
 
@@ -160,7 +160,7 @@ function AssetPicker({
 
               {loading ? (
                 <div className="flex justify-center py-4">
-                  <Loader2 className="w-6 h-6 text-moss-green animate-spin" />
+                  <Loader2 className="w-6 h-6 text-brand-ink animate-spin" />
                 </div>
               ) : filtered.length === 0 ? (
                 <p className="text-center text-sm text-stone-gray/60 py-4">
@@ -208,7 +208,7 @@ function AssetPicker({
                         />
                         {isSelected && (
                           <div className="absolute inset-0 bg-moss-green/20 flex items-center justify-center">
-                            <Check className="w-6 h-6 text-moss-green drop-shadow" />
+                            <Check className="w-6 h-6 text-brand-ink drop-shadow" />
                           </div>
                         )}
                         <div className="absolute bottom-0 inset-x-0 bg-black/60 px-1 py-0.5">
@@ -518,7 +518,7 @@ export default function CreateMapModal({
             <div className="space-y-6">
               {/* Error */}
               {error && (
-                <div role="alert" className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-red-700 text-sm">
+                <div role="alert" className="p-3 bg-danger/10 border border-danger/20 rounded-lg text-danger-ink text-sm">
                   {error}
                 </div>
               )}
@@ -543,7 +543,7 @@ export default function CreateMapModal({
               {/* Map Name */}
               <div>
                 <label className="block text-sm font-medium text-stone-gray mb-1">
-                  Map Name <span className="text-red-500">*</span>
+                  Map Name <span className="text-danger-ink">*</span>
                 </label>
                 <input
                   type="text"
@@ -596,7 +596,7 @@ export default function CreateMapModal({
 
                   {/* Grid Settings */}
                   <div className="border border-moss-green/20 rounded-lg p-4 space-y-4 bg-moss-green/5">
-                    <h3 className="text-sm font-medium text-moss-green">Grid Settings</h3>
+                    <h3 className="text-sm font-medium text-brand-ink">Grid Settings</h3>
 
                     {/* Grid Scale */}
                     <div>
@@ -656,7 +656,7 @@ export default function CreateMapModal({
                             className="mt-0.5 accent-moss-green"
                           />
                           <div>
-                            <span className="text-sm text-stone-gray group-hover:text-moss-green transition-colors">
+                            <span className="text-sm text-stone-gray group-hover:text-brand-ink transition-colors">
                               Flat — every square costs the same
                             </span>
                             <p className="text-xs text-stone-gray/50">D&D 5e default</p>
@@ -672,7 +672,7 @@ export default function CreateMapModal({
                             className="mt-0.5 accent-moss-green"
                           />
                           <div>
-                            <span className="text-sm text-stone-gray group-hover:text-moss-green transition-colors">
+                            <span className="text-sm text-stone-gray group-hover:text-brand-ink transition-colors">
                               Alternating — 5/10/5/10 ft diagonals
                             </span>
                             <p className="text-xs text-stone-gray/50">Pathfinder 2e default</p>
@@ -724,13 +724,13 @@ export default function CreateMapModal({
 
                   {/* Auto-detect suggestion banner */}
                   {detectedGrid && (
-                    <div className="flex items-start gap-2 p-2.5 bg-amber-50 border border-amber-200 rounded-lg">
-                      <Sparkles className="w-4 h-4 text-amber-600 flex-shrink-0 mt-0.5" />
+                    <div className="flex items-start gap-2 p-2.5 bg-warning/10 border border-warning/30 rounded-lg">
+                      <Sparkles className="w-4 h-4 text-warning-ink flex-shrink-0 mt-0.5" />
                       <div className="flex-1 min-w-0">
-                        <p className="text-xs font-medium text-amber-800">Grid detected</p>
-                        <p className="text-xs text-amber-700 mt-0.5">
+                        <p className="text-xs font-medium text-warning-ink">Grid detected</p>
+                        <p className="text-xs text-warning-ink mt-0.5">
                           {detectedGrid.width}×{detectedGrid.height} squares · {detectedGrid.gridSize}px/sq
-                          <span className="text-amber-500 ml-1">
+                          <span className="text-warning-ink ml-1">
                             ({Math.round(detectedGrid.confidence * 100)}% confidence)
                           </span>
                         </p>
@@ -739,14 +739,14 @@ export default function CreateMapModal({
                         <button
                           type="button"
                           onClick={applyDetectedGrid}
-                          className="text-xs px-2 py-1 bg-amber-600 text-white rounded hover:bg-amber-700 transition-colors"
+                          className="text-xs px-2 py-1 bg-warning text-white rounded hover:bg-warning transition-colors"
                         >
                           Apply
                         </button>
                         <button
                           type="button"
                           onClick={() => setDetectedGrid(null)}
-                          className="text-xs px-2 py-1 text-amber-600 hover:text-amber-800 transition-colors"
+                          className="text-xs px-2 py-1 text-warning-ink hover:text-warning-ink transition-colors"
                           aria-label="Dismiss suggestion"
                         >
                           ✕

--- a/frontend/src/components/campaign/CreatureLibrary.tsx
+++ b/frontend/src/components/campaign/CreatureLibrary.tsx
@@ -342,8 +342,8 @@ export default function CreatureLibrary({ isOpen, onClose }: CreatureLibraryProp
           >
             {/* ── Header ── */}
             <div className="flex items-center gap-3 px-5 py-4 border-b border-moss-green/20 bg-parchment/60 sticky top-0 z-10">
-              <BookOpen className="w-5 h-5 text-moss-green flex-shrink-0" />
-              <h2 className="flex-1 text-base font-bold text-moss-green">
+              <BookOpen className="w-5 h-5 text-brand-ink flex-shrink-0" />
+              <h2 className="flex-1 text-base font-bold text-brand-ink">
                 Creature Library
               </h2>
               <span className="text-xs text-stone-gray/60">
@@ -371,7 +371,7 @@ export default function CreatureLibrary({ isOpen, onClose }: CreatureLibraryProp
               {/* Filter toggle */}
               <button
                 onClick={() => setShowFilters(!showFilters)}
-                className="flex items-center gap-1 text-xs text-moss-green hover:text-moss-green/80 transition-colors"
+                className="flex items-center gap-1 text-xs text-brand-ink hover:text-brand-ink/80 transition-colors"
               >
                 {showFilters ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
                 Filters
@@ -406,7 +406,7 @@ export default function CreatureLibrary({ isOpen, onClose }: CreatureLibraryProp
               <div className="flex gap-2">
                 <button
                   onClick={() => setShowCreateForm(true)}
-                  className="flex items-center gap-1 text-xs text-moss-green hover:text-moss-green/80 transition-colors"
+                  className="flex items-center gap-1 text-xs text-brand-ink hover:text-brand-ink/80 transition-colors"
                 >
                   <Plus className="w-3 h-3" /> Create Custom
                 </button>
@@ -414,7 +414,7 @@ export default function CreatureLibrary({ isOpen, onClose }: CreatureLibraryProp
                   <button
                     onClick={handleSeedSrd}
                     disabled={isSeeding}
-                    className="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-500 transition-colors"
+                    className="flex items-center gap-1 text-xs text-info-ink hover:text-info-ink transition-colors"
                   >
                     {isSeeding ? (
                       <><Loader2 className="w-3 h-3 animate-spin" /> Seeding...</>
@@ -425,7 +425,7 @@ export default function CreatureLibrary({ isOpen, onClose }: CreatureLibraryProp
                 )}
               </div>
               {seedResult && (
-                <div className="text-[10px] text-green-600 bg-green-500/10 rounded px-2 py-1">
+                <div className="text-[10px] text-success-ink bg-success/10 rounded px-2 py-1">
                   {seedResult}
                 </div>
               )}
@@ -433,7 +433,7 @@ export default function CreatureLibrary({ isOpen, onClose }: CreatureLibraryProp
 
             {/* ── Error ── */}
             {error && (
-              <div className="mx-4 mt-2 text-xs text-red-600 bg-red-500/10 border border-red-500/20 rounded-cozy px-3 py-2">
+              <div className="mx-4 mt-2 text-xs text-danger-ink bg-danger/10 border border-danger/20 rounded-cozy px-3 py-2">
                 {error}
               </div>
             )}
@@ -446,7 +446,7 @@ export default function CreatureLibrary({ isOpen, onClose }: CreatureLibraryProp
                   className="w-full flex items-center justify-between px-4 py-2 hover:bg-moss-green/5 transition-colors"
                 >
                   <div className="flex items-center gap-2">
-                    <Star className="w-3.5 h-3.5 text-amber-500 fill-amber-500" />
+                    <Star className="w-3.5 h-3.5 text-warning-ink fill-amber-500" />
                     <span className="text-xs font-semibold text-stone-gray uppercase tracking-wide">
                       Favorites
                     </span>
@@ -459,7 +459,7 @@ export default function CreatureLibrary({ isOpen, onClose }: CreatureLibraryProp
                   )}
                 </button>
                 {showFavorites && (
-                  <div className="divide-y divide-moss-green/10 bg-amber-500/[0.02]">
+                  <div className="divide-y divide-moss-green/10 bg-warning/[0.02]">
                     {isLoadingFavorites ? (
                       <div className="flex items-center gap-2 text-stone-gray text-xs py-3 px-4">
                         <Loader2 className="w-3 h-3 animate-spin" />
@@ -500,7 +500,7 @@ export default function CreatureLibrary({ isOpen, onClose }: CreatureLibraryProp
                 </div>
               ) : creatures.length === 0 ? (
                 <div className="text-center py-12 px-6">
-                  <BookOpen className="w-8 h-8 text-moss-green/30 mx-auto mb-2" />
+                  <BookOpen className="w-8 h-8 text-brand-ink/30 mx-auto mb-2" />
                   <p className="text-sm text-stone-gray/70">
                     {searchQuery ? 'No creatures match your search.' : 'No creatures in the library yet.'}
                   </p>
@@ -646,8 +646,8 @@ function CreatureRow({
         ) : (
           <div
             className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 text-white font-bold text-sm ${
-              creature.disposition === 'hostile' ? 'bg-red-500' :
-              creature.disposition === 'friendly' ? 'bg-teal-500' : 'bg-amber-500'
+              creature.disposition === 'hostile' ? 'bg-danger' :
+              creature.disposition === 'friendly' ? 'bg-teal-500' : 'bg-warning'
             }`}
           >
             {creature.name.charAt(0).toUpperCase()}
@@ -665,8 +665,8 @@ function CreatureRow({
         {/* Source badge */}
         <span className={`text-[9px] font-semibold px-1.5 py-0.5 rounded-full flex-shrink-0 ${
           creature.source === 'srd'
-            ? 'bg-blue-500/10 text-blue-600'
-            : 'bg-moss-green/10 text-moss-green'
+            ? 'bg-info/10 text-info-ink'
+            : 'bg-moss-green/10 text-brand-ink'
         }`}>
           {creature.source === 'srd' ? 'SRD' : 'Custom'}
         </span>
@@ -674,13 +674,13 @@ function CreatureRow({
         {/* Favorite star */}
         <button
           onClick={(e) => { e.stopPropagation(); onToggleFavorite(); }}
-          className="flex-shrink-0 p-0.5 rounded hover:bg-amber-500/10 transition-colors"
+          className="flex-shrink-0 p-0.5 rounded hover:bg-warning/10 transition-colors"
           title={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
         >
           <Star className={`w-3.5 h-3.5 transition-colors ${
             isFavorite
-              ? 'text-amber-500 fill-amber-500'
-              : 'text-stone-gray/30 hover:text-amber-400'
+              ? 'text-warning-ink fill-amber-500'
+              : 'text-stone-gray/30 hover:text-warning-ink'
           }`} />
         </button>
 
@@ -700,7 +700,7 @@ function CreatureRow({
             <button
               onClick={onPlace}
               disabled={isPlacing}
-              className="flex-1 flex items-center justify-center gap-1.5 py-1.5 text-xs rounded-cozy bg-moss-green/10 text-moss-green border border-moss-green/30 hover:bg-moss-green/20 transition-colors font-medium"
+              className="flex-1 flex items-center justify-center gap-1.5 py-1.5 text-xs rounded-cozy bg-moss-green/10 text-brand-ink border border-moss-green/30 hover:bg-moss-green/20 transition-colors font-medium"
             >
               {isPlacing ? (
                 <Loader2 className="w-3 h-3 animate-spin" />
@@ -712,7 +712,7 @@ function CreatureRow({
             {creature.source !== 'srd' && (
               <button
                 onClick={onEdit}
-                className="flex items-center gap-1 px-3 py-1.5 text-xs rounded-cozy border border-moss-green/20 text-moss-green hover:bg-moss-green/10 transition-colors"
+                className="flex items-center gap-1 px-3 py-1.5 text-xs rounded-cozy border border-moss-green/20 text-brand-ink hover:bg-moss-green/10 transition-colors"
                 title="Edit creature"
               >
                 <Pencil className="w-3 h-3" /> Edit
@@ -728,7 +728,7 @@ function CreatureRow({
             {creature.source !== 'srd' && (
               <button
                 onClick={onDelete}
-                className="flex items-center gap-1 px-3 py-1.5 text-xs rounded-cozy border border-red-500/20 text-red-500 hover:bg-red-500/10 transition-colors"
+                className="flex items-center gap-1 px-3 py-1.5 text-xs rounded-cozy border border-danger/20 text-danger-ink hover:bg-danger/10 transition-colors"
               >
                 <Trash2 className="w-3 h-3" /> Delete
               </button>
@@ -769,7 +769,7 @@ function NameDescriptionList({
         <button
           type="button"
           onClick={() => onChange([...items, { name: '', description: '' }])}
-          className="text-[10px] text-moss-green hover:text-moss-green/80 flex items-center gap-0.5"
+          className="text-[10px] text-brand-ink hover:text-brand-ink/80 flex items-center gap-0.5"
         >
           <Plus className="w-2.5 h-2.5" /> Add
         </button>
@@ -803,7 +803,7 @@ function NameDescriptionList({
           <button
             type="button"
             onClick={() => onChange(items.filter((_, idx) => idx !== i))}
-            className="p-1 text-red-400 hover:text-red-600 flex-shrink-0 mt-0.5"
+            className="p-1 text-danger-ink hover:text-danger-ink flex-shrink-0 mt-0.5"
             title="Remove"
           >
             <Trash2 className="w-3 h-3" />
@@ -974,7 +974,7 @@ function CreatureForm({ campaignId, gameSystem, editingCreature, onCreated, onEd
   return (
     <div className="border-t border-moss-green/20 bg-parchment/40 p-4 space-y-3 max-h-[70vh] overflow-y-auto">
       <div className="flex items-center justify-between">
-        <h3 className="text-xs font-semibold text-moss-green uppercase tracking-wide">
+        <h3 className="text-xs font-semibold text-brand-ink uppercase tracking-wide">
           {isEdit ? 'Edit Creature' : 'Create Custom Creature'}
         </h3>
         <button onClick={onCancel} className="text-stone-gray hover:text-stone-gray/80 p-0.5">
@@ -983,7 +983,7 @@ function CreatureForm({ campaignId, gameSystem, editingCreature, onCreated, onEd
       </div>
 
       {formError && (
-        <div className="text-xs text-red-600 bg-red-500/10 rounded px-2 py-1">{formError}</div>
+        <div className="text-xs text-danger-ink bg-danger/10 rounded px-2 py-1">{formError}</div>
       )}
 
       {/* Name */}
@@ -1024,7 +1024,7 @@ function CreatureForm({ campaignId, gameSystem, editingCreature, onCreated, onEd
             type="button"
             onClick={() => fileInputRef.current?.click()}
             disabled={isUploading}
-            className="text-[10px] text-moss-green hover:text-moss-green/80 flex items-center gap-1"
+            className="text-[10px] text-brand-ink hover:text-brand-ink/80 flex items-center gap-1"
           >
             {isUploading ? <Loader2 className="w-3 h-3 animate-spin" /> : <Upload className="w-3 h-3" />}
             {imageUrl ? 'Change' : 'Upload'}
@@ -1033,7 +1033,7 @@ function CreatureForm({ campaignId, gameSystem, editingCreature, onCreated, onEd
             <button
               type="button"
               onClick={() => setImageUrl('')}
-              className="text-[10px] text-red-500 hover:text-red-600"
+              className="text-[10px] text-danger-ink hover:text-danger-ink"
             >
               Remove
             </button>
@@ -1120,7 +1120,7 @@ function CreatureForm({ campaignId, gameSystem, editingCreature, onCreated, onEd
             ['CHA', cha, setCha],
           ] as const).map(([label, val, setter]) => (
             <div key={label} className="text-center">
-              <label className="text-[8px] font-bold text-moss-green block">{label}</label>
+              <label className="text-[8px] font-bold text-brand-ink block">{label}</label>
               <input
                 type="number"
                 value={val}
@@ -1148,8 +1148,8 @@ function CreatureForm({ campaignId, gameSystem, editingCreature, onCreated, onEd
               className={`flex-1 py-1 text-[10px] rounded-cozy border transition-all ${
                 disposition === d
                   ? color === 'teal'  ? 'border-teal-500 bg-teal-500/10 text-teal-700 font-semibold'
-                  : color === 'amber' ? 'border-amber-500 bg-amber-500/10 text-amber-700 font-semibold'
-                  :                     'border-red-500 bg-red-500/10 text-red-700 font-semibold'
+                  : color === 'amber' ? 'border-warning/60 bg-warning/10 text-warning-ink font-semibold'
+                  :                     'border-danger/60 bg-danger/10 text-danger-ink font-semibold'
                   : 'border-moss-green/20 hover:border-moss-green/40 text-stone-gray'
               }`}
             >
@@ -1164,7 +1164,7 @@ function CreatureForm({ campaignId, gameSystem, editingCreature, onCreated, onEd
         <button
           type="button"
           onClick={() => setShowAdvanced(!showAdvanced)}
-          className="flex items-center gap-1 text-[10px] text-moss-green hover:text-moss-green/80 font-medium"
+          className="flex items-center gap-1 text-[10px] text-brand-ink hover:text-brand-ink/80 font-medium"
         >
           {showAdvanced ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
           Advanced Stats

--- a/frontend/src/components/campaign/DiceResult.tsx
+++ b/frontend/src/components/campaign/DiceResult.tsx
@@ -23,20 +23,20 @@ export default function DiceResult({ roll, isCurrentUser }: DiceResultProps) {
 
   // Color scheme based on result type
   const getResultColor = () => {
-    if (isCriticalSuccess) return 'text-green-700 dark:text-green-600';
-    if (isCriticalFail) return 'text-red-600 dark:text-red-400';
+    if (isCriticalSuccess) return 'text-success-ink dark:text-success-ink';
+    if (isCriticalFail) return 'text-danger-ink dark:text-danger-ink';
     return 'text-ink';
   };
 
   const getBorderColor = () => {
-    if (isCriticalSuccess) return 'border-green-500/30';
-    if (isCriticalFail) return 'border-red-500/30';
+    if (isCriticalSuccess) return 'border-success/30';
+    if (isCriticalFail) return 'border-danger/30';
     return 'border-ink-muted/20';
   };
 
   const getBgColor = () => {
-    if (isCriticalSuccess) return 'bg-green-50/50 dark:bg-green-900/20';
-    if (isCriticalFail) return 'bg-red-50/50 dark:bg-red-900/20';
+    if (isCriticalSuccess) return 'bg-success/10 dark:bg-success/20';
+    if (isCriticalFail) return 'bg-danger/10 dark:bg-danger/20';
     return isCurrentUser
       ? 'bg-moss-green/10'
       : 'bg-surface/30';
@@ -100,7 +100,7 @@ export default function DiceResult({ roll, isCurrentUser }: DiceResultProps) {
       {/* Expression and Result */}
       <div className="flex items-center gap-3 mb-2">
         <div className="flex items-center gap-2">
-          <Dices className="w-5 h-5 text-moss-green" />
+          <Dices className="w-5 h-5 text-brand-ink" />
           <span className="text-sm font-mono text-ink/90">
             {expression}
           </span>
@@ -146,8 +146,8 @@ export default function DiceResult({ roll, isCurrentUser }: DiceResultProps) {
                             className={`
                               font-mono text-xs px-1 rounded
                               ${!isKept ? 'line-through opacity-40' : ''}
-                              ${isCrit20 ? 'bg-green-500/20 text-green-800 dark:text-green-500 font-bold' : ''}
-                              ${isCrit1 ? 'bg-red-500/20 text-red-700 dark:text-red-300 font-bold' : ''}
+                              ${isCrit20 ? 'bg-success/20 text-success-ink dark:text-success-ink font-bold' : ''}
+                              ${isCrit1 ? 'bg-danger/20 text-danger-ink dark:text-danger-ink font-bold' : ''}
                             `}
                           >
                             {r}
@@ -184,8 +184,8 @@ export default function DiceResult({ roll, isCurrentUser }: DiceResultProps) {
           transition={{ duration: 0.3, delay: 0.2 }}
           className={`
             mt-2 pt-2 border-t text-center text-sm font-bold
-            ${isCriticalSuccess ? 'text-green-700 dark:text-green-600 border-green-500/20' : ''}
-            ${isCriticalFail ? 'text-red-600 dark:text-red-400 border-red-500/20' : ''}
+            ${isCriticalSuccess ? 'text-success-ink dark:text-success-ink border-success/20' : ''}
+            ${isCriticalFail ? 'text-danger-ink dark:text-danger-ink border-danger/20' : ''}
           `}
         >
           {isCriticalSuccess && '🎉 CRITICAL SUCCESS!'}

--- a/frontend/src/components/campaign/DiceRoller.tsx
+++ b/frontend/src/components/campaign/DiceRoller.tsx
@@ -101,13 +101,13 @@ function evaluateLocalRoll(
 
 // Quick roll button configurations with whimsical forest colors
 const QUICK_ROLLS = [
-  { label: 'd4', expression: '1d4', color: 'bg-amber-100/80 dark:bg-amber-900/30 border-amber-300/50 hover:bg-amber-200/80 dark:hover:bg-amber-900/40' },
-  { label: 'd6', expression: '1d6', color: 'bg-green-100/80 dark:bg-green-900/30 border-green-300/50 hover:bg-green-200/80 dark:hover:bg-green-900/40' },
-  { label: 'd8', expression: '1d8', color: 'bg-purple-100/80 dark:bg-purple-900/30 border-purple-300/50 hover:bg-purple-200/80 dark:hover:bg-purple-900/40' },
-  { label: 'd10', expression: '1d10', color: 'bg-orange-100/80 dark:bg-orange-900/30 border-orange-300/50 hover:bg-orange-200/80 dark:hover:bg-orange-900/40' },
+  { label: 'd4', expression: '1d4', color: 'bg-warning/15 dark:bg-warning/30 border-warning/50 hover:bg-warning/80 dark:hover:bg-warning/40' },
+  { label: 'd6', expression: '1d6', color: 'bg-success/15 dark:bg-success/30 border-success/50 hover:bg-success/80 dark:hover:bg-success/40' },
+  { label: 'd8', expression: '1d8', color: 'bg-spirit/15 dark:bg-spirit/30 border-spirit/50 hover:bg-spirit/80 dark:hover:bg-spirit/40' },
+  { label: 'd10', expression: '1d10', color: 'bg-warning/15 dark:bg-warning/30 border-warning/50 hover:bg-warning/80 dark:hover:bg-warning/40' },
   { label: 'd12', expression: '1d12', color: 'bg-teal-100/80 dark:bg-teal-900/30 border-teal-300/50 hover:bg-teal-200/80 dark:hover:bg-teal-900/40' },
-  { label: 'd20', expression: '1d20', color: 'bg-rose-100/80 dark:bg-rose-900/30 border-rose-300/50 hover:bg-rose-200/80 dark:hover:bg-rose-900/40' },
-  { label: 'd100', expression: '1d100', color: 'bg-indigo-100/80 dark:bg-indigo-900/30 border-indigo-300/50 hover:bg-indigo-200/80 dark:hover:bg-indigo-900/40' },
+  { label: 'd20', expression: '1d20', color: 'bg-danger/15 dark:bg-danger/30 border-danger/50 hover:bg-danger/80 dark:hover:bg-danger/40' },
+  { label: 'd100', expression: '1d100', color: 'bg-info/15 dark:bg-info/30 border-info/50 hover:bg-info/80 dark:hover:bg-info/40' },
 ];
 
 const SPECIAL_ROLLS = [
@@ -457,7 +457,7 @@ export default function DiceRoller() {
       <div className="flex-shrink-0 p-3 border-b border-ink-muted/20">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <Dices className="w-4 h-4 text-moss-green dark:text-moss-green" />
+            <Dices className="w-4 h-4 text-brand-ink dark:text-brand-ink" />
             <h2 className="text-base font-semibold text-ink">
               Dice Roller
             </h2>
@@ -466,7 +466,7 @@ export default function DiceRoller() {
           {userRole === 'DM' && rolls.length > 0 && (
             <button
               onClick={handleClearHistory}
-              className="flex items-center gap-1 px-2 py-1 text-xs rounded-md border border-red-500/30 bg-red-50/50 dark:bg-red-900/20 text-red-600 dark:text-red-400 hover:bg-red-100/50 dark:hover:bg-red-900/30 transition-all"
+              className="flex items-center gap-1 px-2 py-1 text-xs rounded-md border border-danger/30 bg-danger/10 dark:bg-danger/20 text-danger-ink dark:text-danger-ink hover:bg-danger/15 dark:hover:bg-danger/30 transition-all"
               title="Clear all roll history"
             >
               <Trash2 className="w-3 h-3" />
@@ -541,7 +541,7 @@ export default function DiceRoller() {
               initial={{ opacity: 0, height: 0 }}
               animate={{ opacity: 1, height: 'auto' }}
               exit={{ opacity: 0, height: 0 }}
-              className="mb-2 flex items-center gap-2 text-red-600 dark:text-red-400 text-xs"
+              className="mb-2 flex items-center gap-2 text-danger-ink dark:text-danger-ink text-xs"
             >
               <AlertCircle className="w-3 h-3 flex-shrink-0" />
               <span>{error}</span>
@@ -635,7 +635,7 @@ export default function DiceRoller() {
               checked={isSecret}
               onChange={(e) => setIsSecret(e.target.checked)}
               disabled={isRolling}
-              className="w-3 h-3 rounded border-ink-muted/30 text-moss-green focus:ring-brand/50 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-3 h-3 rounded border-ink-muted/30 text-brand-ink focus:ring-brand/50 disabled:opacity-50 disabled:cursor-not-allowed"
             />
             <label
               htmlFor="secretRoll"
@@ -653,10 +653,10 @@ export default function DiceRoller() {
               disabled={isRolling || !expression.trim() || rateLimitCooldown > 0}
               className="
                 flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-md
-                bg-green-700 hover:bg-green-600 text-white font-semibold text-xs shadow-sm
+                bg-success hover:bg-success text-white font-semibold text-xs shadow-sm
                 disabled:opacity-50 disabled:cursor-not-allowed
                 transition-all duration-200
-                focus:outline-none focus:ring-2 focus:ring-green-500/50
+                focus:outline-none focus:ring-2 focus:ring-success/50
               "
             >
               {isRolling ? (
@@ -698,7 +698,7 @@ export default function DiceRoller() {
 
         {/* Hint / Rate Limit Countdown */}
         {rateLimitCooldown > 0 ? (
-          <div className="mt-1.5 text-xs text-red-600 dark:text-red-400 text-center font-medium">
+          <div className="mt-1.5 text-xs text-danger-ink dark:text-danger-ink text-center font-medium">
             You may roll again in: {rateLimitCooldown} second{rateLimitCooldown !== 1 ? 's' : ''}
           </div>
         ) : (
@@ -737,7 +737,7 @@ export default function DiceRoller() {
               {/* Header */}
               <div className="p-4 border-b border-ink/10">
                 <div className="flex items-center gap-2">
-                  <EyeOff className="w-5 h-5 text-brand" />
+                  <EyeOff className="w-5 h-5 text-brand-ink" />
                   <h3 className="text-lg font-semibold text-ink">
                     Secret Roll
                   </h3>

--- a/frontend/src/components/campaign/DmFogControls.tsx
+++ b/frontend/src/components/campaign/DmFogControls.tsx
@@ -74,7 +74,7 @@ export default function DmFogControls({
           onClick={() => onFogModeChange(fogMode === 'fog-hide' ? null : 'fog-hide')}
           className={`flex-1 flex items-center justify-center gap-1.5 px-2 py-1.5 rounded text-xs font-medium transition-colors ${
             fogMode === 'fog-hide'
-              ? 'bg-orange-600/30 text-orange-400 border border-orange-500/50'
+              ? 'bg-warning/30 text-warning-ink border border-warning/50'
               : 'bg-stone-700/50 text-stone-300 border border-stone-600/50 hover:bg-stone-700'
           }`}
           title="Hide brush — paint to hide areas from players"
@@ -127,8 +127,8 @@ export default function DmFogControls({
           onClick={handleHideAll}
           className={`flex-1 px-2 py-1 rounded text-xs font-medium transition-colors ${
             confirmHideAll
-              ? 'bg-orange-500 text-white animate-pulse'
-              : 'bg-stone-700/50 text-stone-300 border border-stone-600/50 hover:bg-orange-700/30 hover:text-orange-400'
+              ? 'bg-warning text-white animate-pulse'
+              : 'bg-stone-700/50 text-stone-300 border border-stone-600/50 hover:bg-warning/30 hover:text-warning-ink'
           }`}
           title={confirmHideAll ? 'Click again to confirm: hide entire map' : 'Hide all — cover entire map with fog'}
           aria-label="Hide entire map"

--- a/frontend/src/components/campaign/DmWallControls.tsx
+++ b/frontend/src/components/campaign/DmWallControls.tsx
@@ -266,7 +266,7 @@ export default function DmWallControls({
               >
                 Merge point
               </button>
-              <span className="text-[10px] text-stone-500 px-1">Remove this point and join the two segments into one straight wall</span>
+              <span className="text-[10px] text-stone-300 px-1">Remove this point and join the two segments into one straight wall</span>
             </div>
           )}
 

--- a/frontend/src/components/campaign/EditMapModal.tsx
+++ b/frontend/src/components/campaign/EditMapModal.tsx
@@ -73,14 +73,14 @@ function AssetPicker({
       <div className="flex items-center justify-between">
         <label className="block text-sm font-medium text-stone-gray">
           {label}
-          {required && <span className="text-red-500 ml-1">*</span>}
+          {required && <span className="text-danger-ink ml-1">*</span>}
         </label>
         <div className="flex gap-2">
           {selectedAssetId && (
             <button
               type="button"
               onClick={() => onSelect(null)}
-              className="text-xs text-red-500 hover:text-red-700"
+              className="text-xs text-danger-ink hover:text-danger-ink"
             >
               Clear
             </button>
@@ -104,10 +104,10 @@ function AssetPicker({
             className="w-12 h-12 object-cover rounded"
             onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
           />
-          <span className="text-sm text-moss-green font-medium truncate flex-1">
+          <span className="text-sm text-brand-ink font-medium truncate flex-1">
             {selectedAsset?.name ?? 'Current image'}
           </span>
-          <Check className="w-4 h-4 text-moss-green flex-shrink-0" />
+          <Check className="w-4 h-4 text-brand-ink flex-shrink-0" />
         </div>
       )}
 
@@ -133,7 +133,7 @@ function AssetPicker({
 
               {loading ? (
                 <div className="flex justify-center py-4">
-                  <Loader2 className="w-6 h-6 text-moss-green animate-spin" />
+                  <Loader2 className="w-6 h-6 text-brand-ink animate-spin" />
                 </div>
               ) : filtered.length === 0 ? (
                 <p className="text-center text-sm text-stone-gray/60 py-4">
@@ -180,7 +180,7 @@ function AssetPicker({
                         />
                         {isSelected && (
                           <div className="absolute inset-0 bg-moss-green/20 flex items-center justify-center">
-                            <Check className="w-6 h-6 text-moss-green drop-shadow" />
+                            <Check className="w-6 h-6 text-brand-ink drop-shadow" />
                           </div>
                         )}
                         <div className="absolute bottom-0 inset-x-0 bg-black/60 px-1 py-0.5">
@@ -498,7 +498,7 @@ export default function EditMapModal({
             <div className="space-y-6">
               <p className="text-xs text-ink-muted -mt-4 truncate">{map.name}</p>
               {error && (
-                <div role="alert" className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-red-700 text-sm">
+                <div role="alert" className="p-3 bg-danger/10 border border-danger/20 rounded-lg text-danger-ink text-sm">
                   {error}
                 </div>
               )}
@@ -518,7 +518,7 @@ export default function EditMapModal({
 
               <div>
                 <label className="block text-sm font-medium text-stone-gray mb-1">
-                  Map Name <span className="text-red-500">*</span>
+                  Map Name <span className="text-danger-ink">*</span>
                 </label>
                 <input
                   type="text"
@@ -571,7 +571,7 @@ export default function EditMapModal({
 
                   {/* Grid Settings */}
                   <div className="border border-moss-green/20 rounded-lg p-4 space-y-4 bg-moss-green/5">
-                    <h3 className="text-sm font-medium text-moss-green">Grid Settings</h3>
+                    <h3 className="text-sm font-medium text-brand-ink">Grid Settings</h3>
 
                     {/* Grid Scale */}
                     <div>
@@ -631,7 +631,7 @@ export default function EditMapModal({
                             className="mt-0.5 accent-moss-green"
                           />
                           <div>
-                            <span className="text-sm text-stone-gray group-hover:text-moss-green transition-colors">
+                            <span className="text-sm text-stone-gray group-hover:text-brand-ink transition-colors">
                               Flat — every square costs the same
                             </span>
                             <p className="text-xs text-stone-gray/50">D&D 5e default</p>
@@ -647,7 +647,7 @@ export default function EditMapModal({
                             className="mt-0.5 accent-moss-green"
                           />
                           <div>
-                            <span className="text-sm text-stone-gray group-hover:text-moss-green transition-colors">
+                            <span className="text-sm text-stone-gray group-hover:text-brand-ink transition-colors">
                               Alternating — 5/10/5/10 ft diagonals
                             </span>
                             <p className="text-xs text-stone-gray/50">Pathfinder 2e default</p>
@@ -669,7 +669,7 @@ export default function EditMapModal({
                       aria-label="Enable dynamic lighting"
                     />
                     <div>
-                      <span className="text-sm text-stone-gray group-hover:text-moss-green transition-colors">
+                      <span className="text-sm text-stone-gray group-hover:text-brand-ink transition-colors">
                         Enable Dynamic Lighting
                       </span>
                       <p className="text-xs text-stone-gray/50">Raycasting visibility — players only see what their tokens can see through walls</p>
@@ -718,13 +718,13 @@ export default function EditMapModal({
 
                   {/* Auto-detect suggestion banner — only shown when image is changed */}
                   {detectedGrid && (
-                    <div className="flex items-start gap-2 p-2.5 bg-amber-50 border border-amber-200 rounded-lg">
-                      <Sparkles className="w-4 h-4 text-amber-600 flex-shrink-0 mt-0.5" />
+                    <div className="flex items-start gap-2 p-2.5 bg-warning/10 border border-warning/30 rounded-lg">
+                      <Sparkles className="w-4 h-4 text-warning-ink flex-shrink-0 mt-0.5" />
                       <div className="flex-1 min-w-0">
-                        <p className="text-xs font-medium text-amber-800">Grid detected</p>
-                        <p className="text-xs text-amber-700 mt-0.5">
+                        <p className="text-xs font-medium text-warning-ink">Grid detected</p>
+                        <p className="text-xs text-warning-ink mt-0.5">
                           {detectedGrid.width}×{detectedGrid.height} squares · {detectedGrid.gridSize}px/sq
-                          <span className="text-amber-500 ml-1">
+                          <span className="text-warning-ink ml-1">
                             ({Math.round(detectedGrid.confidence * 100)}% confidence)
                           </span>
                         </p>
@@ -733,14 +733,14 @@ export default function EditMapModal({
                         <button
                           type="button"
                           onClick={applyDetectedGrid}
-                          className="text-xs px-2 py-1 bg-amber-600 text-white rounded hover:bg-amber-700 transition-colors"
+                          className="text-xs px-2 py-1 bg-warning text-white rounded hover:bg-warning transition-colors"
                         >
                           Apply
                         </button>
                         <button
                           type="button"
                           onClick={() => setDetectedGrid(null)}
-                          className="text-xs px-2 py-1 text-amber-600 hover:text-amber-800 transition-colors"
+                          className="text-xs px-2 py-1 text-warning-ink hover:text-warning-ink transition-colors"
                           aria-label="Dismiss suggestion"
                         >
                           ✕

--- a/frontend/src/components/campaign/EndSessionModal.tsx
+++ b/frontend/src/components/campaign/EndSessionModal.tsx
@@ -98,12 +98,12 @@ export default function EndSessionModal({
                 checked={saveState}
                 onChange={(e) => setSaveState(e.target.checked)}
                 disabled={isSubmitting}
-                className="w-4 h-4 rounded border-moss-green/30 text-moss-green focus:ring-moss-green/50 cursor-pointer"
+                className="w-4 h-4 rounded border-moss-green/30 text-brand-ink focus:ring-moss-green/50 cursor-pointer"
               />
             </div>
             <div>
               <div className="flex items-center gap-2">
-                <Save className="w-3.5 h-3.5 text-moss-green" />
+                <Save className="w-3.5 h-3.5 text-brand-ink" />
                 <span className="text-sm font-medium text-stone-gray">Save game state</span>
               </div>
               <p className="text-xs text-warm-gray mt-0.5">

--- a/frontend/src/components/campaign/InitiativeTracker.tsx
+++ b/frontend/src/components/campaign/InitiativeTracker.tsx
@@ -39,9 +39,9 @@ import type { CombatState, CombatantEntry, Token } from '@/types';
 // ---------------------------------------------------------------------------
 
 function dispositionColor(entry: CombatantEntry): string {
-  if (entry.type === 'player') return 'text-moss-green';
-  if (entry.disposition === 'friendly') return 'text-moss-green';
-  if (entry.disposition === 'hostile') return 'text-red-600';
+  if (entry.type === 'player') return 'text-brand-ink';
+  if (entry.disposition === 'friendly') return 'text-brand-ink';
+  if (entry.disposition === 'hostile') return 'text-danger-ink';
   return 'text-stone-gray';
 }
 
@@ -83,7 +83,7 @@ function AddCombatantModal({ tokens, combatantIds, mapId: _mapId, onAdd, onClose
         className="bg-soft-cream border-2 border-moss-green/30 rounded-xl shadow-2xl w-full max-w-sm mx-4"
       >
         <div className="flex items-center justify-between p-4 border-b border-moss-green/20">
-          <h3 className="font-bold text-moss-green">Add Combatant</h3>
+          <h3 className="font-bold text-brand-ink">Add Combatant</h3>
           <button onClick={onClose} className="p-1 rounded hover:bg-stone-gray/10 transition-colors">
             <XCircle className="w-4 h-4 text-stone-gray" />
           </button>
@@ -112,7 +112,7 @@ function AddCombatantModal({ tokens, combatantIds, mapId: _mapId, onAdd, onClose
                   </div>
                 )}
                 <div className="flex-1 min-w-0">
-                  <div className="font-medium text-sm text-moss-green truncate">{token.name}</div>
+                  <div className="font-medium text-sm text-brand-ink truncate">{token.name}</div>
                   <div className="text-xs text-stone-gray capitalize">
                     {token.type ?? 'npc'}{token.disposition ? ` · ${token.disposition}` : ''}
                   </div>
@@ -218,7 +218,7 @@ function CombatantRow({
 
       {/* Name + disposition */}
       <div className="flex-1 min-w-0">
-        <div className={`text-sm font-medium truncate ${isActive ? 'text-warm-amber' : 'text-moss-green'}`}>
+        <div className={`text-sm font-medium truncate ${isActive ? 'text-warm-amber' : 'text-brand-ink'}`}>
           {entry.name}
         </div>
         {entry.hp && (
@@ -262,14 +262,14 @@ function CombatantRow({
           <button
             onClick={() => onRoll(entry.tokenId)}
             title="Roll initiative for this token"
-            className="p-1 rounded hover:bg-moss-green/10 text-stone-gray hover:text-moss-green transition-colors"
+            className="p-1 rounded hover:bg-moss-green/10 text-stone-gray hover:text-brand-ink transition-colors"
           >
             <Dices className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => onRemove(entry.tokenId)}
             title="Remove from initiative"
-            className="p-1 rounded hover:bg-red-100 text-stone-gray hover:text-red-600 transition-colors"
+            className="p-1 rounded hover:bg-danger/10 text-stone-gray hover:text-danger-ink transition-colors"
           >
             <Trash2 className="w-3.5 h-3.5" />
           </button>
@@ -433,8 +433,8 @@ export default function InitiativeTracker() {
           className="w-full flex items-center justify-between px-4 py-3 bg-parchment/40 hover:bg-parchment/60 transition-colors"
         >
           <div className="flex items-center gap-2">
-            <Swords className="w-4 h-4 text-moss-green" />
-            <span className="font-semibold text-moss-green text-sm">Initiative Tracker</span>
+            <Swords className="w-4 h-4 text-brand-ink" />
+            <span className="font-semibold text-brand-ink text-sm">Initiative Tracker</span>
             {combatState.active && (
               <span className="text-xs font-bold text-warm-amber bg-warm-amber/10 border border-warm-amber/20 rounded px-1.5 py-0.5">
                 Round {combatState.round}
@@ -503,7 +503,7 @@ export default function InitiativeTracker() {
                 {mapId && (
                   <button
                     onClick={() => setShowAddModal(true)}
-                    className="w-full flex items-center justify-center gap-2 py-1.5 px-3 text-xs font-medium text-moss-green border border-dashed border-moss-green/30 rounded-lg hover:bg-moss-green/5 transition-colors"
+                    className="w-full flex items-center justify-center gap-2 py-1.5 px-3 text-xs font-medium text-brand-ink border border-dashed border-moss-green/30 rounded-lg hover:bg-moss-green/5 transition-colors"
                   >
                     <Plus className="w-3.5 h-3.5" />
                     Add Combatant
@@ -532,7 +532,7 @@ export default function InitiativeTracker() {
                         </button>
                         <button
                           onClick={handleEnd}
-                          className="flex items-center justify-center gap-1.5 py-1.5 px-3 text-xs font-semibold border border-red-200 text-red-600 rounded-lg hover:bg-red-50 transition-colors"
+                          className="flex items-center justify-center gap-1.5 py-1.5 px-3 text-xs font-semibold border border-danger/30 text-danger-ink rounded-lg hover:bg-danger/10 transition-colors"
                           title="End combat"
                         >
                           <XCircle className="w-3.5 h-3.5" />

--- a/frontend/src/components/campaign/InvitationModal.tsx
+++ b/frontend/src/components/campaign/InvitationModal.tsx
@@ -124,7 +124,7 @@ export default function InvitationModal({
 
           {/* Campaign Details */}
           <div className="mb-6 p-4 rounded-lg bg-parchment/50 border border-moss-green/20">
-            <h3 className="text-lg font-semibold text-moss-green mb-2">
+            <h3 className="text-lg font-semibold text-brand-ink mb-2">
               {invitation.campaign?.name}
             </h3>
             {invitation.campaign?.description && (
@@ -152,7 +152,7 @@ export default function InvitationModal({
 
           {/* Character Selection */}
           <div className="mb-6">
-            <h3 className="text-lg font-semibold text-moss-green mb-3">
+            <h3 className="text-lg font-semibold text-brand-ink mb-3">
               Select Characters (Optional)
             </h3>
             <p className="text-sm text-warm-gray mb-4">
@@ -183,7 +183,7 @@ export default function InvitationModal({
                       type="checkbox"
                       checked={selectedCharacterIds.includes(character.id)}
                       onChange={() => toggleCharacter(character.id)}
-                      className="w-4 h-4 rounded border-moss-green/30 text-moss-green focus:ring-moss-green focus:ring-offset-0"
+                      className="w-4 h-4 rounded border-moss-green/30 text-brand-ink focus:ring-moss-green focus:ring-offset-0"
                     />
                     {character.tokenImageUrl ? (
                       <img
@@ -193,7 +193,7 @@ export default function InvitationModal({
                       />
                     ) : (
                       <div className="w-10 h-10 rounded-full bg-moss-green/10 border border-moss-green/20 flex items-center justify-center">
-                        <span className="text-sm text-moss-green font-semibold">
+                        <span className="text-sm text-brand-ink font-semibold">
                           {character.name.charAt(0).toUpperCase()}
                         </span>
                       </div>

--- a/frontend/src/components/campaign/InvitePlayerModal.tsx
+++ b/frontend/src/components/campaign/InvitePlayerModal.tsx
@@ -96,7 +96,7 @@ export default function InvitePlayerModal({
         {/* User list */}
         {loading ? (
           <div className="flex items-center justify-center py-10">
-            <Loader2 className="w-7 h-7 text-brand animate-spin" />
+            <Loader2 className="w-7 h-7 text-brand-ink animate-spin" />
           </div>
         ) : users.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-10 gap-2 text-center">

--- a/frontend/src/components/campaign/MapCanvas.tsx
+++ b/frontend/src/components/campaign/MapCanvas.tsx
@@ -2718,7 +2718,7 @@ export default function MapCanvas({ onEditToken }: MapCanvasProps) {
               variant="secondary" className={`p-2 ${showRuler ? 'bg-moss-green/20' : ''}`}
               title="Ruler — measure distance"
             >
-              <Ruler className={`w-4 h-4 ${showRuler ? 'text-moss-green' : ''}`} />
+              <Ruler className={`w-4 h-4 ${showRuler ? 'text-brand-ink' : ''}`} />
             </Button>
             {showRuler && (
               <Button
@@ -2746,7 +2746,7 @@ export default function MapCanvas({ onEditToken }: MapCanvasProps) {
               variant="secondary" className={`p-2 ${showAoE ? 'bg-moss-green/20' : ''}`}
               title="AoE Shape — area of effect overlay"
             >
-              <Zap className={`w-4 h-4 ${showAoE ? 'text-moss-green' : ''}`} />
+              <Zap className={`w-4 h-4 ${showAoE ? 'text-brand-ink' : ''}`} />
             </Button>
           </>
         )}
@@ -2985,8 +2985,10 @@ export default function MapCanvas({ onEditToken }: MapCanvasProps) {
             onClick={() => setDmPreviewPlayerView((prev) => !prev)}
             className={`px-3 py-1.5 rounded text-xs font-medium transition-colors border ${
               dmPreviewPlayerView
-                ? 'bg-blue-600/30 text-blue-300 border-blue-500/50'
-                : 'bg-stone-800/90 text-stone-300 border-stone-600/50 hover:bg-stone-700/90'
+                ? 'bg-info/30 text-info-ink border-info/50'
+                // ink/paper invert together, so this stays a legible contrast
+                // chip over the map on both light and dark themes
+                : 'bg-ink/85 text-paper border-ink/40 hover:bg-ink'
             }`}
             title={dmPreviewPlayerView ? 'Back to DM view (see all)' : 'Preview how players see this map with dynamic lighting'}
             aria-label="Toggle DM player view preview"
@@ -3006,7 +3008,7 @@ export default function MapCanvas({ onEditToken }: MapCanvasProps) {
       {/* AoE panel */}
       {showAoE && currentMap && (
         <div className="absolute top-12 left-2 z-10 p-3 space-y-3 w-52 shadow-xl rounded-xl border border-moss-green/30 bg-parchment/95 backdrop-blur-sm">
-          <p className="text-xs font-semibold text-moss-green">AoE Shape</p>
+          <p className="text-xs font-semibold text-brand-ink">AoE Shape</p>
 
           {/* Shape selector */}
           <div className="flex flex-wrap gap-1.5">
@@ -3016,8 +3018,8 @@ export default function MapCanvas({ onEditToken }: MapCanvasProps) {
                 onClick={() => setAoEConfig((prev) => ({ ...prev, shape }))}
                 className={`text-xs px-2 py-1 rounded border transition-colors capitalize ${
                   aoeConfig.shape === shape
-                    ? 'bg-moss-green/20 border-moss-green/60 text-moss-green font-medium'
-                    : 'border-stone-gray/30 text-stone-gray hover:border-moss-green/40 hover:text-moss-green'
+                    ? 'bg-moss-green/20 border-moss-green/60 text-brand-ink font-medium'
+                    : 'border-stone-gray/30 text-stone-gray hover:border-moss-green/40 hover:text-brand-ink'
                 }`}
               >
                 {shape === 'sphere' ? 'Circle' : shape.charAt(0).toUpperCase() + shape.slice(1)}
@@ -3065,7 +3067,7 @@ export default function MapCanvas({ onEditToken }: MapCanvasProps) {
                 <button
                   key={ft}
                   onClick={() => setAoEConfig((prev) => ({ ...prev, sizeFt: ft }))}
-                  className="text-xs px-1.5 py-0.5 rounded bg-moss-green/10 hover:bg-moss-green/20 text-moss-green border border-moss-green/20 transition-colors"
+                  className="text-xs px-1.5 py-0.5 rounded bg-moss-green/10 hover:bg-moss-green/20 text-brand-ink border border-moss-green/20 transition-colors"
                 >
                   {ft} ft
                 </button>
@@ -3077,7 +3079,7 @@ export default function MapCanvas({ onEditToken }: MapCanvasProps) {
           {aoeOrigin && (
             <button
               onClick={() => setAoEOrigin(null)}
-              className="text-xs text-stone-gray hover:text-red-500 transition-colors"
+              className="text-xs text-stone-gray hover:text-danger-ink transition-colors"
             >
               × Clear placement
             </button>
@@ -3102,7 +3104,7 @@ export default function MapCanvas({ onEditToken }: MapCanvasProps) {
       {hoverToken && hoverCoords && (
         <div className="absolute bottom-4 left-4 glass-panel px-3 py-1.5 bg-parchment/90 backdrop-blur-sm">
           <div className="flex items-center gap-2">
-            <span className="text-xs text-moss-green font-semibold">
+            <span className="text-xs text-brand-ink font-semibold">
               {hoverToken.name}
             </span>
             <span className="text-xs text-stone-gray font-mono">
@@ -3131,7 +3133,7 @@ export default function MapCanvas({ onEditToken }: MapCanvasProps) {
       {imageError && (
         <div className="absolute inset-0 flex items-center justify-center bg-parchment/80">
           <div className="glass-panel p-4 text-center">
-            <p className="text-sm text-red-600 mb-2">{imageError}</p>
+            <p className="text-sm text-danger-ink mb-2">{imageError}</p>
             <p className="text-xs text-stone-gray">Check map image URL</p>
           </div>
         </div>
@@ -3141,7 +3143,7 @@ export default function MapCanvas({ onEditToken }: MapCanvasProps) {
       {!currentMap && (
         <div className="absolute inset-0 flex items-center justify-center">
           <div className="text-center">
-            <Grid3x3 className="w-12 h-12 text-moss-green/30 mx-auto mb-3" />
+            <Grid3x3 className="w-12 h-12 text-brand-ink/30 mx-auto mb-3" />
             <p className="text-sm text-warm-gray mb-2">No map loaded</p>
             <p className="text-xs text-stone-gray/70">
               Upload a map to get started
@@ -3218,7 +3220,7 @@ export default function MapCanvas({ onEditToken }: MapCanvasProps) {
               {/* Edit Token — NPC and Object tokens */}
               {isNpcOrObject && (
                 <button
-                  className="w-full px-4 py-2 text-left text-sm text-moss-green font-medium hover:bg-moss-green/10 transition-colors"
+                  className="w-full px-4 py-2 text-left text-sm text-brand-ink font-medium hover:bg-moss-green/10 transition-colors"
                   onClick={() => {
                     setContextMenu(null);
                     onEditToken?.(cmToken);
@@ -3358,7 +3360,7 @@ export default function MapCanvas({ onEditToken }: MapCanvasProps) {
                 ) : (
                   <button
                     disabled={isMovingTokenLayer}
-                    className="w-full px-4 py-2 text-left text-sm text-moss-green hover:bg-moss-green/10 transition-colors disabled:opacity-50"
+                    className="w-full px-4 py-2 text-left text-sm text-brand-ink hover:bg-moss-green/10 transition-colors disabled:opacity-50"
                     onClick={async () => {
                       if (!campaign?.id || !currentMap?.id) return;
                       setIsMovingTokenLayer(true);
@@ -3449,7 +3451,7 @@ export default function MapCanvas({ onEditToken }: MapCanvasProps) {
               <div className="h-px bg-moss-green/20 my-1" />
 
               <button
-                className="w-full px-4 py-2 text-left text-sm text-red-600 hover:bg-red-500/10 transition-colors"
+                className="w-full px-4 py-2 text-left text-sm text-danger-ink hover:bg-danger/10 transition-colors"
                 onClick={async () => {
                   if (!campaign?.id || !currentMap?.id) return;
                   const token = contextMenu.token;
@@ -3529,7 +3531,7 @@ export default function MapCanvas({ onEditToken }: MapCanvasProps) {
           {/* Open — available when door is closed */}
           {doorContextMenu.door.type === 'door-closed' && (
             <button
-              className="w-full px-4 py-2 text-left text-sm text-moss-green hover:bg-moss-green/10 transition-colors"
+              className="w-full px-4 py-2 text-left text-sm text-brand-ink hover:bg-moss-green/10 transition-colors"
               onClick={() => changeDoorType(doorContextMenu.door, 'door-open')}
             >
               Open Door
@@ -3539,7 +3541,7 @@ export default function MapCanvas({ onEditToken }: MapCanvasProps) {
           {/* Close — available when door is open */}
           {doorContextMenu.door.type === 'door-open' && (
             <button
-              className="w-full px-4 py-2 text-left text-sm text-moss-green hover:bg-moss-green/10 transition-colors"
+              className="w-full px-4 py-2 text-left text-sm text-brand-ink hover:bg-moss-green/10 transition-colors"
               onClick={() => changeDoorType(doorContextMenu.door, 'door-closed')}
             >
               Close Door
@@ -3549,7 +3551,7 @@ export default function MapCanvas({ onEditToken }: MapCanvasProps) {
           {/* Lock — DM only, available when door is open or closed */}
           {isDM && doorContextMenu.door.type !== 'door-locked' && (
             <button
-              className="w-full px-4 py-2 text-left text-sm text-red-500 hover:bg-red-500/10 transition-colors"
+              className="w-full px-4 py-2 text-left text-sm text-danger-ink hover:bg-danger/10 transition-colors"
               onClick={() => changeDoorType(doorContextMenu.door, 'door-locked')}
             >
               Lock Door
@@ -3559,7 +3561,7 @@ export default function MapCanvas({ onEditToken }: MapCanvasProps) {
           {/* Unlock — DM only, available when door is locked */}
           {isDM && doorContextMenu.door.type === 'door-locked' && (
             <button
-              className="w-full px-4 py-2 text-left text-sm text-moss-green hover:bg-moss-green/10 transition-colors"
+              className="w-full px-4 py-2 text-left text-sm text-brand-ink hover:bg-moss-green/10 transition-colors"
               onClick={() => changeDoorType(doorContextMenu.door, 'door-closed')}
             >
               Unlock Door

--- a/frontend/src/components/campaign/MapManager.tsx
+++ b/frontend/src/components/campaign/MapManager.tsx
@@ -91,7 +91,7 @@ function TokenTransferConfirmation({
       </div>
 
       <div className="flex gap-2 text-xs">
-        <button type="button" onClick={selectAll} className="text-moss-green hover:underline">
+        <button type="button" onClick={selectAll} className="text-brand-ink hover:underline">
           Select all
         </button>
         <span className="text-stone-gray/40">·</span>
@@ -224,7 +224,7 @@ function MapCard({
 
       {/* Info */}
       <div className="p-3">
-        <h3 className="font-semibold text-moss-green truncate text-sm mb-0.5">{map.name}</h3>
+        <h3 className="font-semibold text-brand-ink truncate text-sm mb-0.5">{map.name}</h3>
         <p className="text-xs text-stone-gray/60">
           {map.width}×{map.height} grid · {map.gridSize}px/sq
         </p>
@@ -238,8 +238,8 @@ function MapCard({
             title={isActive ? 'Already active' : 'Set as active map'}
             className={`flex-1 text-xs py-1.5 px-2 rounded-lg transition-colors flex items-center justify-center gap-1 ${
               isActive
-                ? 'bg-moss-green/10 text-moss-green/50 cursor-not-allowed'
-                : 'bg-moss-green/10 hover:bg-moss-green/20 text-moss-green'
+                ? 'bg-moss-green/10 text-brand-ink/50 cursor-not-allowed'
+                : 'bg-moss-green/10 hover:bg-moss-green/20 text-brand-ink'
             }`}
           >
             {isSwitchingToThis ? (
@@ -263,7 +263,7 @@ function MapCard({
             type="button"
             onClick={() => onExport(map)}
             title="Export as .uvtt file"
-            className="p-1.5 rounded-lg bg-moss-green/10 hover:bg-moss-green/20 text-moss-green transition-colors"
+            className="p-1.5 rounded-lg bg-moss-green/10 hover:bg-moss-green/20 text-brand-ink transition-colors"
           >
             <Download className="w-3.5 h-3.5" />
           </button>
@@ -275,8 +275,8 @@ function MapCard({
             title={isActive ? 'Cannot delete the active map' : 'Delete map'}
             className={`p-1.5 rounded-lg transition-colors ${
               isActive
-                ? 'bg-red-500/5 text-red-400/40 cursor-not-allowed'
-                : 'bg-red-500/10 hover:bg-red-500/20 text-red-600'
+                ? 'bg-danger/5 text-danger-ink/40 cursor-not-allowed'
+                : 'bg-danger/10 hover:bg-danger/20 text-danger-ink'
             }`}
           >
             <Trash2 className="w-3.5 h-3.5" />
@@ -546,9 +546,9 @@ export default function MapManager({ isOpen, onClose }: MapManagerProps) {
               <div className="sticky top-0 z-10 bg-moss-green/10 backdrop-blur-sm border-b border-moss-green/20 px-6 py-4">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3">
-                    <MapPin className="w-6 h-6 text-moss-green" />
+                    <MapPin className="w-6 h-6 text-brand-ink" />
                     <div>
-                      <h2 className="text-xl font-bold text-moss-green">Map Library</h2>
+                      <h2 className="text-xl font-bold text-brand-ink">Map Library</h2>
                       <p className="text-xs text-stone-gray">{campaign.name}</p>
                     </div>
                   </div>
@@ -595,14 +595,14 @@ export default function MapManager({ isOpen, onClose }: MapManagerProps) {
               {/* Content */}
               <div className="p-6">
                 {error && (
-                  <div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-red-700 text-sm flex items-start gap-2">
+                  <div className="mb-4 p-3 bg-danger/10 border border-danger/20 rounded-lg text-danger-ink text-sm flex items-start gap-2">
                     <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
                     {error}
                   </div>
                 )}
 
                 {importSuccess && (
-                  <div className="mb-4 p-3 bg-moss-green/10 border border-moss-green/30 rounded-lg text-moss-green text-sm flex items-start gap-2">
+                  <div className="mb-4 p-3 bg-moss-green/10 border border-moss-green/30 rounded-lg text-brand-ink text-sm flex items-start gap-2">
                     <CheckCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
                     {importSuccess}
                   </div>
@@ -610,7 +610,7 @@ export default function MapManager({ isOpen, onClose }: MapManagerProps) {
 
                 {isLoading ? (
                   <div className="flex items-center justify-center py-20">
-                    <Loader2 className="w-10 h-10 text-moss-green animate-spin" />
+                    <Loader2 className="w-10 h-10 text-brand-ink animate-spin" />
                   </div>
                 ) : maps.length === 0 ? (
                   <div className="text-center py-16 space-y-3">

--- a/frontend/src/components/campaign/NpcQuickEditor.tsx
+++ b/frontend/src/components/campaign/NpcQuickEditor.tsx
@@ -450,7 +450,7 @@ export default function NpcQuickEditor({ token, campaignId, mapId, onClose, onTo
                 />
               ) : (
                 <div className="w-10 h-10 rounded-full bg-moss-green/10 flex items-center justify-center">
-                  <Heart className="w-5 h-5 text-moss-green/40" />
+                  <Heart className="w-5 h-5 text-brand-ink/40" />
                 </div>
               )}
               <div className="absolute inset-0 rounded-full bg-black/0 group-hover:bg-black/40 transition-colors flex items-center justify-center">
@@ -464,14 +464,14 @@ export default function NpcQuickEditor({ token, campaignId, mapId, onClose, onTo
               value={name}
               onChange={(e) => setName(e.target.value)}
               onBlur={handleNameBlur}
-              className="flex-1 text-base font-bold text-moss-green bg-transparent border-b border-transparent hover:border-moss-green/30 focus:border-moss-green focus:outline-none px-0"
+              className="flex-1 text-base font-bold text-brand-ink bg-transparent border-b border-transparent hover:border-moss-green/30 focus:border-moss-green focus:outline-none px-0"
             />
 
             {/* Badge */}
             <span className={`text-[10px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0 ${
               tokenType === TokenType.OBJECT
                 ? 'bg-stone-gray/10 text-stone-gray'
-                : 'bg-moss-green/10 text-moss-green'
+                : 'bg-moss-green/10 text-brand-ink'
             }`}>
               {tokenType === TokenType.OBJECT ? 'Object' : 'NPC'}
             </span>
@@ -496,7 +496,7 @@ export default function NpcQuickEditor({ token, campaignId, mapId, onClose, onTo
                     <button
                       onClick={() => imageFileRef.current?.click()}
                       disabled={isUploadingImage}
-                      className="flex items-center gap-1 text-[10px] text-moss-green hover:text-moss-green/80 disabled:opacity-40 transition-colors"
+                      className="flex items-center gap-1 text-[10px] text-brand-ink hover:text-brand-ink/80 disabled:opacity-40 transition-colors"
                     >
                       {isUploadingImage ? (
                         <Loader2 className="w-3 h-3 animate-spin" />
@@ -505,7 +505,7 @@ export default function NpcQuickEditor({ token, campaignId, mapId, onClose, onTo
                       )}
                       {isUploadingImage ? 'Uploading...' : 'Upload'}
                     </button>
-                    <span className="text-stone-300">·</span>
+                    <span className="text-ink-muted">·</span>
                     <button
                       onClick={() => setShowImagePicker(false)}
                       className="text-[10px] text-stone-gray hover:text-stone-gray/80 transition-colors"
@@ -528,12 +528,12 @@ export default function NpcQuickEditor({ token, campaignId, mapId, onClose, onTo
                       title="Use colored-letter placeholder"
                       className={`relative rounded-cozy overflow-hidden border-2 aspect-square transition-all flex items-center justify-center ${
                         !token.imageUrl
-                          ? 'border-moss-green ring-1 ring-moss-green/30 bg-stone-700/60'
-                          : 'border-transparent hover:border-moss-green/40 bg-stone-700/40'
+                          ? 'border-moss-green ring-1 ring-moss-green/30 bg-ink-muted/25'
+                          : 'border-transparent hover:border-moss-green/40 bg-ink-muted/20'
                       }`}
                     >
-                      <span className="text-sm font-bold text-stone-400">?</span>
-                      <span className="absolute bottom-0 text-[7px] text-stone-500">None</span>
+                      <span className="text-sm font-bold text-ink-secondary">?</span>
+                      <span className="absolute bottom-0 text-[7px] text-ink-muted">None</span>
                     </button>
                     {assets.map((asset) => {
                       const isSelected = token.imageUrl?.includes(asset.id);
@@ -555,7 +555,7 @@ export default function NpcQuickEditor({ token, campaignId, mapId, onClose, onTo
                           />
                           {isSelected && (
                             <div className="absolute inset-0 bg-moss-green/25 flex items-center justify-center">
-                              <Check className="w-3 h-3 text-moss-green drop-shadow" />
+                              <Check className="w-3 h-3 text-brand-ink drop-shadow" />
                             </div>
                           )}
                         </button>
@@ -573,7 +573,7 @@ export default function NpcQuickEditor({ token, campaignId, mapId, onClose, onTo
                           This is an SRD creature. A custom copy will be created in your campaign library.
                         </p>
                         {duplicateWarning && (
-                          <p className="text-[11px] text-amber-700 bg-amber-500/10 rounded px-2 py-1">
+                          <p className="text-[11px] text-warning-ink bg-warning/10 rounded px-2 py-1">
                             {duplicateWarning}
                           </p>
                         )}
@@ -594,7 +594,7 @@ export default function NpcQuickEditor({ token, campaignId, mapId, onClose, onTo
                           <button
                             onClick={handleConfirmDuplicate}
                             disabled={isSavingToCreature || !duplicateName.trim()}
-                            className="flex-1 py-1.5 text-[10px] rounded-cozy bg-moss-green/10 border border-moss-green/30 hover:bg-moss-green/20 text-moss-green transition-colors font-medium disabled:opacity-40"
+                            className="flex-1 py-1.5 text-[10px] rounded-cozy bg-moss-green/10 border border-moss-green/30 hover:bg-moss-green/20 text-brand-ink transition-colors font-medium disabled:opacity-40"
                           >
                             {isSavingToCreature ? (
                               <span className="flex items-center justify-center gap-1">
@@ -616,7 +616,7 @@ export default function NpcQuickEditor({ token, campaignId, mapId, onClose, onTo
                       <button
                         onClick={handleSaveImageToCreature}
                         disabled={isSavingToCreature}
-                        className="w-full flex items-center justify-center gap-1.5 py-1.5 text-xs rounded-cozy border border-moss-green/30 hover:bg-moss-green/10 text-moss-green transition-colors"
+                        className="w-full flex items-center justify-center gap-1.5 py-1.5 text-xs rounded-cozy border border-moss-green/30 hover:bg-moss-green/10 text-brand-ink transition-colors"
                       >
                         {isSavingToCreature ? (
                           <Loader2 className="w-3 h-3 animate-spin" />
@@ -659,7 +659,7 @@ export default function NpcQuickEditor({ token, campaignId, mapId, onClose, onTo
                       <div className="text-center text-sm font-semibold mt-1" style={{ color: hpColor }}>
                         {hp.current} / {hp.max}
                         {hp.temp > 0 && (
-                          <span className="text-blue-400 ml-1 text-xs">+{hp.temp} temp</span>
+                          <span className="text-info-ink ml-1 text-xs">+{hp.temp} temp</span>
                         )}
                       </div>
                     </div>
@@ -670,7 +670,7 @@ export default function NpcQuickEditor({ token, campaignId, mapId, onClose, onTo
                         <button
                           key={d}
                           onClick={() => adjustHp(d)}
-                          className="flex-1 py-1.5 text-xs rounded-cozy border border-red-500/30 hover:bg-red-500/10 text-red-600 transition-colors font-medium"
+                          className="flex-1 py-1.5 text-xs rounded-cozy border border-danger/30 hover:bg-danger/10 text-danger-ink transition-colors font-medium"
                         >
                           {d}
                         </button>
@@ -679,7 +679,7 @@ export default function NpcQuickEditor({ token, campaignId, mapId, onClose, onTo
                         <button
                           key={d}
                           onClick={() => adjustHp(d)}
-                          className="flex-1 py-1.5 text-xs rounded-cozy border border-green-500/30 hover:bg-green-500/10 text-green-600 transition-colors font-medium"
+                          className="flex-1 py-1.5 text-xs rounded-cozy border border-success/30 hover:bg-success/10 text-success-ink transition-colors font-medium"
                         >
                           +{d}
                         </button>
@@ -759,14 +759,14 @@ export default function NpcQuickEditor({ token, campaignId, mapId, onClose, onTo
                     <div className="flex gap-1">
                       <button
                         onClick={() => setEditingStatBlock(!editingStatBlock)}
-                        className="text-[10px] text-moss-green hover:text-moss-green/80 transition-colors"
+                        className="text-[10px] text-brand-ink hover:text-brand-ink/80 transition-colors"
                       >
                         {editingStatBlock ? 'View' : 'Edit'}
                       </button>
-                      <span className="text-stone-300">·</span>
+                      <span className="text-ink-muted">·</span>
                       <button
                         onClick={handleRemoveStatBlock}
-                        className="text-[10px] text-red-500 hover:text-red-600 transition-colors"
+                        className="text-[10px] text-danger-ink hover:text-danger-ink transition-colors"
                       >
                         Remove
                       </button>
@@ -833,8 +833,8 @@ export default function NpcQuickEditor({ token, campaignId, mapId, onClose, onTo
                 <div className="flex gap-2">
                   {([
                     { d: TokenDisposition.FRIENDLY, label: 'Friendly', activeClass: 'border-teal-500 bg-teal-500/10 text-teal-700 font-semibold' },
-                    { d: TokenDisposition.NEUTRAL,  label: 'Neutral',  activeClass: 'border-amber-500 bg-amber-500/10 text-amber-700 font-semibold' },
-                    { d: TokenDisposition.HOSTILE,  label: 'Hostile',  activeClass: 'border-red-500 bg-red-500/10 text-red-700 font-semibold' },
+                    { d: TokenDisposition.NEUTRAL,  label: 'Neutral',  activeClass: 'border-warning/60 bg-warning/10 text-warning-ink font-semibold' },
+                    { d: TokenDisposition.HOSTILE,  label: 'Hostile',  activeClass: 'border-danger/60 bg-danger/10 text-danger-ink font-semibold' },
                   ] as const).map(({ d, label, activeClass }) => (
                     <button
                       key={d}
@@ -880,7 +880,7 @@ export default function NpcQuickEditor({ token, campaignId, mapId, onClose, onTo
                     <button
                       key={c}
                       onClick={() => toggleCondition(c)}
-                      className="flex items-center gap-1 px-2 py-1 text-xs rounded-full bg-amber-500/15 border border-amber-500/30 text-amber-700 hover:bg-red-500/10 hover:border-red-500/30 hover:text-red-700 transition-colors"
+                      className="flex items-center gap-1 px-2 py-1 text-xs rounded-full bg-warning/15 border border-warning/30 text-warning-ink hover:bg-danger/10 hover:border-danger/30 hover:text-danger-ink transition-colors"
                     >
                       {c} <X className="w-3 h-3" />
                     </button>
@@ -898,7 +898,7 @@ export default function NpcQuickEditor({ token, campaignId, mapId, onClose, onTo
                       onClick={() => toggleCondition(c)}
                       className={`px-2 py-1 text-xs rounded-cozy border transition-all ${
                         active
-                          ? 'border-amber-500/50 bg-amber-500/15 text-amber-700'
+                          ? 'border-warning/50 bg-warning/15 text-warning-ink'
                           : 'border-moss-green/20 hover:border-moss-green/40 text-stone-gray'
                       }`}
                     >
@@ -962,7 +962,7 @@ export default function NpcQuickEditor({ token, campaignId, mapId, onClose, onTo
                   className={`flex-1 flex items-center justify-center gap-1.5 py-2 text-xs rounded-cozy border transition-all ${
                     visible
                       ? 'border-stone-gray/30 hover:border-stone-gray/50 text-stone-gray'
-                      : 'border-moss-green/40 bg-moss-green/10 text-moss-green font-semibold'
+                      : 'border-moss-green/40 bg-moss-green/10 text-brand-ink font-semibold'
                   }`}
                 >
                   {visible ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
@@ -972,7 +972,7 @@ export default function NpcQuickEditor({ token, campaignId, mapId, onClose, onTo
                 <button
                   onClick={handleRemove}
                   disabled={isRemoving}
-                  className="flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-cozy border border-red-500/30 hover:bg-red-500/10 text-red-600 transition-colors"
+                  className="flex items-center justify-center gap-1.5 px-3 py-2 text-xs rounded-cozy border border-danger/30 hover:bg-danger/10 text-danger-ink transition-colors"
                 >
                   <Trash2 className="w-3.5 h-3.5" />
                   {isRemoving ? 'Removing…' : 'Remove'}

--- a/frontend/src/components/campaign/NpcRollPicker.tsx
+++ b/frontend/src/components/campaign/NpcRollPicker.tsx
@@ -73,7 +73,7 @@ const Section: React.FC<SectionProps> = ({ title, rolls, onRoll }) => {
           onClick={() => onRoll(opt)}
           className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-stone-gray hover:bg-moss-green/10 transition-colors text-left"
         >
-          <Dices className="w-3 h-3 text-moss-green flex-shrink-0" />
+          <Dices className="w-3 h-3 text-brand-ink flex-shrink-0" />
           <span className="flex-1">{opt.label}</span>
         </button>
       ))}
@@ -182,7 +182,7 @@ export default function NpcRollPicker({
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-2 bg-moss-green/10 border-b border-moss-green/20">
         <div className="flex items-center gap-2">
-          <Dices className="w-4 h-4 text-moss-green" />
+          <Dices className="w-4 h-4 text-brand-ink" />
           <span className="text-sm font-semibold text-stone-gray truncate">
             Roll for {token.name}
           </span>
@@ -201,7 +201,7 @@ export default function NpcRollPicker({
               onClick={() => setModeOpen((o) => !o)}
               className="w-full flex items-center justify-between px-2 py-1.5 rounded border border-moss-green/30 bg-paper/60 text-sm text-ink-secondary hover:bg-paper/80 transition-colors"
             >
-              <span className={mode !== 'normal' ? 'text-amber-600 font-medium' : ''}>
+              <span className={mode !== 'normal' ? 'text-warning-ink font-medium' : ''}>
                 {modeLabels[mode]}
               </span>
               <ChevronDown className="w-3.5 h-3.5 text-warm-gray" />
@@ -213,7 +213,7 @@ export default function NpcRollPicker({
                     key={m}
                     onClick={() => { setMode(m); setModeOpen(false); }}
                     className={`w-full text-left px-3 py-2 text-sm hover:bg-moss-green/10 transition-colors first:rounded-t-lg last:rounded-b-lg ${
-                      mode === m ? 'font-semibold text-moss-green' : 'text-stone-gray'
+                      mode === m ? 'font-semibold text-brand-ink' : 'text-stone-gray'
                     }`}
                   >
                     {modeLabels[m]}
@@ -261,7 +261,7 @@ export default function NpcRollPicker({
           />
           <button
             onClick={handleCustomRoll}
-            className="flex items-center gap-1 px-2 py-1 text-xs rounded-cozy bg-moss-green/10 text-moss-green border border-moss-green/30 hover:bg-moss-green/20 transition-colors"
+            className="flex items-center gap-1 px-2 py-1 text-xs rounded-cozy bg-moss-green/10 text-brand-ink border border-moss-green/30 hover:bg-moss-green/20 transition-colors"
             title="Roll"
           >
             <Plus className="w-3 h-3" /> Roll
@@ -276,7 +276,7 @@ export default function NpcRollPicker({
           className="input-cozy w-full text-xs py-1"
         />
         {customError && (
-          <div className="text-[10px] text-red-600">{customError}</div>
+          <div className="text-[10px] text-danger-ink">{customError}</div>
         )}
       </div>
     </div>

--- a/frontend/src/components/campaign/PartyRoster.tsx
+++ b/frontend/src/components/campaign/PartyRoster.tsx
@@ -28,8 +28,8 @@ export default function PartyRoster() {
     <div className="glass-panel p-4 space-y-4">
       {/* Header */}
       <div className="flex items-center gap-2 pb-2 border-b border-moss-green/20">
-        <Users className="w-5 h-5 text-moss-green" />
-        <h3 className="text-lg font-semibold text-moss-green">Party Roster</h3>
+        <Users className="w-5 h-5 text-brand-ink" />
+        <h3 className="text-lg font-semibold text-brand-ink">Party Roster</h3>
       </div>
 
       {/* Members List */}
@@ -52,7 +52,7 @@ export default function PartyRoster() {
                   <RoleIcon
                     className={`w-4 h-4 ${
                       membership.role === 'DM'
-                        ? 'text-moss-green'
+                        ? 'text-brand-ink'
                         : 'text-spirit-purple'
                     }`}
                   />

--- a/frontend/src/components/campaign/SessionControls.tsx
+++ b/frontend/src/components/campaign/SessionControls.tsx
@@ -160,7 +160,7 @@ export default function SessionControls() {
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Clock className="w-4 h-4 text-warm-amber" />
-            <h3 className="text-sm font-semibold text-moss-green">Session Controls</h3>
+            <h3 className="text-sm font-semibold text-brand-ink">Session Controls</h3>
           </div>
 
           {/* Session number + timer */}
@@ -170,8 +170,8 @@ export default function SessionControls() {
               <span className="font-medium">{activeSession.sessionNumber}</span>
               {isActive && elapsed && (
                 <>
-                  <span className="text-moss-green/30">·</span>
-                  <span className="font-mono text-moss-green">{elapsed}</span>
+                  <span className="text-brand-ink/30">·</span>
+                  <span className="font-mono text-brand-ink">{elapsed}</span>
                 </>
               )}
             </div>
@@ -183,7 +183,7 @@ export default function SessionControls() {
           <div
             className={`w-2 h-2 rounded-full flex-shrink-0 ${
               isActive
-                ? 'bg-green-500 animate-pulse'
+                ? 'bg-success animate-pulse'
                 : isPaused
                   ? 'bg-warm-amber'
                   : 'bg-stone-gray/40'
@@ -237,7 +237,7 @@ export default function SessionControls() {
             <button
               onClick={() => setIsEndModalOpen(true)}
               disabled={isLoading}
-              className="w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg border border-red-200 text-red-600 hover:bg-red-50 transition-colors text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg border border-danger/30 text-danger-ink hover:bg-danger/10 transition-colors text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <Square className="w-4 h-4" />
               End Session

--- a/frontend/src/components/campaign/SessionSidebar.tsx
+++ b/frontend/src/components/campaign/SessionSidebar.tsx
@@ -112,7 +112,7 @@ export default function SessionSidebar() {
                 'text-xs font-medium transition-colors duration-150',
                 'focus:outline-none focus-visible:ring-2 focus-visible:ring-brand',
                 active
-                  ? 'text-brand bg-surface-light/70 border-b-2 border-brand -mb-px'
+                  ? 'text-brand-ink bg-surface-light/70 border-b-2 border-brand -mb-px'
                   : 'text-ink-muted hover:text-ink hover:bg-surface/60'
               )}
             >

--- a/frontend/src/components/campaign/SpiritLayerControls.tsx
+++ b/frontend/src/components/campaign/SpiritLayerControls.tsx
@@ -284,7 +284,7 @@ export default function SpiritLayerControls({ isOpen, onClose }: SpiritLayerCont
             <div className="flex items-center justify-between px-5 py-4 border-b border-moss-green/20 bg-parchment/60 sticky top-0 z-10">
               <div className="flex items-center gap-2">
                 <Ghost className="w-5 h-5 text-spirit-purple" />
-                <h2 className="text-lg font-bold text-moss-green">Spirit Layer</h2>
+                <h2 className="text-lg font-bold text-brand-ink">Spirit Layer</h2>
               </div>
               <Button
                 onClick={onClose}
@@ -299,7 +299,7 @@ export default function SpiritLayerControls({ isOpen, onClose }: SpiritLayerCont
             <div className="flex-1 overflow-y-auto p-5 space-y-6">
               {/* Error */}
               {errorMsg && (
-                <div className="px-4 py-3 bg-red-500/10 border border-red-500/20 text-red-700 text-sm rounded-cozy">
+                <div className="px-4 py-3 bg-danger/10 border border-danger/20 text-danger-ink text-sm rounded-cozy">
                   {errorMsg}
                 </div>
               )}
@@ -327,7 +327,7 @@ export default function SpiritLayerControls({ isOpen, onClose }: SpiritLayerCont
                     className={`relative flex items-center gap-2 px-4 py-2 rounded-cozy font-medium text-sm transition-colors ${
                       enabled
                         ? 'bg-spirit-purple text-white hover:bg-spirit-purple/80'
-                        : 'bg-transparent border border-brand text-brand hover:bg-brand hover:text-white focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-2'
+                        : 'bg-transparent border border-brand text-brand-ink hover:bg-brand hover:text-white focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-2'
                     }`}
                     title={enabled ? 'Close the veil' : 'Open the veil'}
                   >
@@ -357,7 +357,7 @@ export default function SpiritLayerControls({ isOpen, onClose }: SpiritLayerCont
                     className={`flex items-center gap-2 px-4 py-2 rounded-cozy font-medium text-sm transition-colors ${
                       dmViewBothPlanes
                         ? 'bg-spirit-purple/20 text-spirit-purple hover:bg-spirit-purple/30'
-                        : 'bg-transparent border border-brand text-brand hover:bg-brand hover:text-white focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-2'
+                        : 'bg-transparent border border-brand text-brand-ink hover:bg-brand hover:text-white focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-2'
                     }`}
                     title={dmViewBothPlanes ? 'Switch to single-plane view' : 'Switch to dual-plane view'}
                   >
@@ -512,7 +512,7 @@ export default function SpiritLayerControls({ isOpen, onClose }: SpiritLayerCont
                             disabled={isToggling}
                             className={`flex-shrink-0 p-2 rounded-cozy transition-colors ${
                               token.visible
-                                ? 'text-moss-green hover:bg-moss-green/10'
+                                ? 'text-brand-ink hover:bg-moss-green/10'
                                 : 'text-stone-gray/50 hover:bg-stone-gray/10'
                             }`}
                             title={token.visible ? 'Hide token' : 'Show token'}

--- a/frontend/src/components/campaign/TokenManager.tsx
+++ b/frontend/src/components/campaign/TokenManager.tsx
@@ -356,8 +356,8 @@ export default function TokenManager({ isOpen, onClose }: TokenManagerProps) {
             {/* Header */}
             <div className="flex items-center justify-between px-5 py-4 border-b border-moss-green/20 bg-parchment/60 sticky top-0 z-10">
               <div className="flex items-center gap-2">
-                <Swords className="w-5 h-5 text-moss-green" />
-                <h2 className="text-lg font-bold text-moss-green">Token Manager</h2>
+                <Swords className="w-5 h-5 text-brand-ink" />
+                <h2 className="text-lg font-bold text-brand-ink">Token Manager</h2>
               </div>
               <Button onClick={onClose} variant="secondary" className="p-1.5" title="Close">
                 <X className="w-4 h-4" />
@@ -368,7 +368,7 @@ export default function TokenManager({ isOpen, onClose }: TokenManagerProps) {
             <div className="flex-1 overflow-y-auto p-5 space-y-6">
               {/* Error */}
               {error && (
-                <div className="px-4 py-3 bg-red-500/10 border border-red-500/20 text-red-700 text-sm rounded-cozy">
+                <div className="px-4 py-3 bg-danger/10 border border-danger/20 text-danger-ink text-sm rounded-cozy">
                   {error}
                 </div>
               )}
@@ -395,7 +395,7 @@ export default function TokenManager({ isOpen, onClose }: TokenManagerProps) {
                         onClick={() => setTokenType(type)}
                         className={`flex-1 py-1.5 text-xs rounded-cozy border transition-all ${
                           tokenType === type
-                            ? 'border-moss-green bg-moss-green/10 text-moss-green font-semibold'
+                            ? 'border-moss-green bg-moss-green/10 text-brand-ink font-semibold'
                             : 'border-moss-green/20 hover:border-moss-green/40 text-stone-gray'
                         }`}
                       >
@@ -427,7 +427,7 @@ export default function TokenManager({ isOpen, onClose }: TokenManagerProps) {
                       onClick={() => fileInputRef.current?.click()}
                       disabled={isUploading}
                       title="Upload a new token image"
-                      className="flex items-center gap-1 text-xs text-moss-green hover:text-moss-green/80 disabled:opacity-40 transition-colors"
+                      className="flex items-center gap-1 text-xs text-brand-ink hover:text-brand-ink/80 disabled:opacity-40 transition-colors"
                     >
                       {isUploading ? (
                         <Loader2 className="w-3 h-3 animate-spin" />
@@ -438,7 +438,7 @@ export default function TokenManager({ isOpen, onClose }: TokenManagerProps) {
                     </button>
                   </div>
                   {uploadError && (
-                    <p className="text-[11px] text-red-600 mb-1.5">{uploadError}</p>
+                    <p className="text-[11px] text-danger-ink mb-1.5">{uploadError}</p>
                   )}
                   {isLoadingAssets ? (
                     <div className="flex items-center gap-2 text-stone-gray text-sm py-4">
@@ -462,12 +462,12 @@ export default function TokenManager({ isOpen, onClose }: TokenManagerProps) {
                         title="Use colored-letter placeholder"
                         className={`relative rounded-cozy overflow-hidden border-2 aspect-square transition-all flex items-center justify-center ${
                           !selectedAsset
-                            ? 'border-moss-green ring-2 ring-moss-green/30 bg-stone-700/60'
-                            : 'border-transparent hover:border-moss-green/40 bg-stone-700/40'
+                            ? 'border-moss-green ring-2 ring-moss-green/30 bg-ink-muted/25'
+                            : 'border-transparent hover:border-moss-green/40 bg-ink-muted/20'
                         }`}
                       >
-                        <span className="text-lg font-bold text-stone-400">?</span>
-                        <span className="absolute bottom-0.5 text-[8px] text-stone-500">None</span>
+                        <span className="text-lg font-bold text-ink-secondary">?</span>
+                        <span className="absolute bottom-0.5 text-[8px] text-ink-muted">None</span>
                       </button>
                       {assets.map((asset) => {
                         const isSelected = selectedAsset?.id === asset.id;
@@ -489,7 +489,7 @@ export default function TokenManager({ isOpen, onClose }: TokenManagerProps) {
                             />
                             {isSelected && (
                               <div className="absolute inset-0 bg-moss-green/25 flex items-center justify-center">
-                                <Check className="w-4 h-4 text-moss-green drop-shadow" />
+                                <Check className="w-4 h-4 text-brand-ink drop-shadow" />
                               </div>
                             )}
                           </button>
@@ -530,7 +530,7 @@ export default function TokenManager({ isOpen, onClose }: TokenManagerProps) {
                         title={desc}
                         className={`flex-1 py-1.5 text-xs rounded-cozy border transition-all ${
                           displayMode === mode
-                            ? 'border-moss-green bg-moss-green/10 text-moss-green font-semibold'
+                            ? 'border-moss-green bg-moss-green/10 text-brand-ink font-semibold'
                             : 'border-moss-green/20 hover:border-moss-green/40 text-stone-gray'
                         }`}
                       >
@@ -565,8 +565,8 @@ export default function TokenManager({ isOpen, onClose }: TokenManagerProps) {
                             className={`flex-1 py-1.5 text-xs rounded-cozy border transition-all ${
                               disposition === d
                                 ? color === 'teal'  ? 'border-teal-500 bg-teal-500/10 text-teal-700 font-semibold'
-                                : color === 'amber' ? 'border-amber-500 bg-amber-500/10 text-amber-700 font-semibold'
-                                :                    'border-red-500 bg-red-500/10 text-red-700 font-semibold'
+                                : color === 'amber' ? 'border-warning/60 bg-warning/10 text-warning-ink font-semibold'
+                                :                    'border-danger/60 bg-danger/10 text-danger-ink font-semibold'
                                 : 'border-moss-green/20 hover:border-moss-green/40 text-stone-gray'
                             }`}
                           >
@@ -680,7 +680,7 @@ export default function TokenManager({ isOpen, onClose }: TokenManagerProps) {
                           onClick={() => setTokenSize(opt.value)}
                           className={`flex-1 py-1.5 text-center text-xs rounded-cozy border transition-all ${
                             isSelected
-                              ? 'border-moss-green bg-moss-green/10 text-moss-green font-semibold'
+                              ? 'border-moss-green bg-moss-green/10 text-brand-ink font-semibold'
                               : 'border-moss-green/20 hover:border-moss-green/40 text-stone-gray'
                           }`}
                         >
@@ -703,7 +703,7 @@ export default function TokenManager({ isOpen, onClose }: TokenManagerProps) {
                         onClick={() => setTokenLayer(TokenLayer.TOKEN)}
                         className={`flex-1 py-1.5 text-xs rounded-cozy border transition-all ${
                           tokenLayer === TokenLayer.TOKEN
-                            ? 'border-moss-green bg-moss-green/10 text-moss-green font-semibold'
+                            ? 'border-moss-green bg-moss-green/10 text-brand-ink font-semibold'
                             : 'border-moss-green/20 hover:border-moss-green/40 text-stone-gray'
                         }`}
                       >
@@ -745,7 +745,7 @@ export default function TokenManager({ isOpen, onClose }: TokenManagerProps) {
                 )}
 
                 {!currentMap && (
-                  <p className="text-xs text-amber-700 mb-2">
+                  <p className="text-xs text-warning-ink mb-2">
                     No map is currently loaded — load a map first.
                   </p>
                 )}
@@ -819,7 +819,7 @@ export default function TokenManager({ isOpen, onClose }: TokenManagerProps) {
                                   className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${
                                     isSpirit
                                       ? 'bg-spirit-purple/15 text-spirit-purple'
-                                      : 'bg-moss-green/10 text-moss-green'
+                                      : 'bg-moss-green/10 text-brand-ink'
                                   }`}
                                 >
                                   {isSpirit ? 'Spirit' : 'Material'}
@@ -849,7 +849,7 @@ export default function TokenManager({ isOpen, onClose }: TokenManagerProps) {
                                 {isTogglingVis ? (
                                   <Loader2 className="w-3.5 h-3.5 animate-spin text-stone-gray" />
                                 ) : token.visible ? (
-                                  <Eye className="w-3.5 h-3.5 text-moss-green" />
+                                  <Eye className="w-3.5 h-3.5 text-brand-ink" />
                                 ) : (
                                   <EyeOff className="w-3.5 h-3.5 text-stone-gray/40" />
                                 )}
@@ -894,13 +894,13 @@ export default function TokenManager({ isOpen, onClose }: TokenManagerProps) {
                               <button
                                 onClick={() => handleDelete(token)}
                                 disabled={isDeleting}
-                                className="p-1.5 rounded hover:bg-red-500/10 transition-colors"
+                                className="p-1.5 rounded hover:bg-danger/10 transition-colors"
                                 title="Remove from map"
                               >
                                 {isDeleting ? (
                                   <Loader2 className="w-3.5 h-3.5 animate-spin text-stone-gray" />
                                 ) : (
-                                  <Trash2 className="w-3.5 h-3.5 text-red-400/60 hover:text-red-500 transition-colors" />
+                                  <Trash2 className="w-3.5 h-3.5 text-danger-ink/60 hover:text-danger-ink transition-colors" />
                                 )}
                               </button>
                             </div>

--- a/frontend/src/components/campaign/TokenRoster.tsx
+++ b/frontend/src/components/campaign/TokenRoster.tsx
@@ -160,7 +160,7 @@ function TokenRow({ token, campaignId, mapId, onEditToken }: TokenRowProps) {
           <button
             onClick={() => onEditToken(token)}
             title="Edit token"
-            className="p-1 rounded hover:bg-moss-green/10 text-moss-green transition-colors"
+            className="p-1 rounded hover:bg-moss-green/10 text-brand-ink transition-colors"
           >
             <Edit2 className="w-3 h-3" />
           </button>
@@ -194,7 +194,7 @@ function TokenRow({ token, campaignId, mapId, onEditToken }: TokenRowProps) {
           onClick={handleDelete}
           disabled={isDeleting}
           title="Remove from map"
-          className="p-1 rounded hover:bg-red-500/10 text-red-500/60 hover:text-red-600 transition-colors disabled:opacity-40"
+          className="p-1 rounded hover:bg-danger/10 text-danger-ink/60 hover:text-danger-ink transition-colors disabled:opacity-40"
         >
           {isDeleting ? (
             <Loader2 className="w-3 h-3 animate-spin" />
@@ -277,7 +277,7 @@ export default function TokenRoster({ onEditToken }: TokenRosterProps) {
         className="w-full flex items-center justify-between px-3 py-2.5 hover:bg-moss-green/5 transition-colors"
       >
         <div className="flex items-center gap-2">
-          <span className="text-sm font-semibold text-moss-green">Token Roster</span>
+          <span className="text-sm font-semibold text-brand-ink">Token Roster</span>
           <span className="text-xs text-stone-gray/60">({tokens.length})</span>
         </div>
         {isCollapsed ? (

--- a/frontend/src/components/campaign/TokenTemplateLibrary.tsx
+++ b/frontend/src/components/campaign/TokenTemplateLibrary.tsx
@@ -222,8 +222,8 @@ export default function TokenTemplateLibrary({ isOpen, onClose }: TokenTemplateL
           >
             {/* Header */}
             <div className="flex items-center gap-3 px-5 py-4 border-b border-moss-green/20 bg-parchment/60 sticky top-0 z-10">
-              <Package className="w-5 h-5 text-moss-green flex-shrink-0" />
-              <h2 className="flex-1 text-base font-bold text-moss-green">Token Templates</h2>
+              <Package className="w-5 h-5 text-brand-ink flex-shrink-0" />
+              <h2 className="flex-1 text-base font-bold text-brand-ink">Token Templates</h2>
               <span className="text-xs text-stone-gray/60">
                 {total} template{total !== 1 ? 's' : ''}
               </span>
@@ -258,7 +258,7 @@ export default function TokenTemplateLibrary({ isOpen, onClose }: TokenTemplateL
                 </select>
                 <button
                   onClick={() => { setEditingTemplate(null); setShowForm(true); }}
-                  className="flex items-center gap-1 text-xs text-moss-green hover:text-moss-green/80 transition-colors"
+                  className="flex items-center gap-1 text-xs text-brand-ink hover:text-brand-ink/80 transition-colors"
                 >
                   <Plus className="w-3 h-3" /> New Template
                 </button>
@@ -267,7 +267,7 @@ export default function TokenTemplateLibrary({ isOpen, onClose }: TokenTemplateL
 
             {/* Error */}
             {error && (
-              <div className="mx-4 mt-2 text-xs text-red-600 bg-red-500/10 border border-red-500/20 rounded-cozy px-3 py-2">
+              <div className="mx-4 mt-2 text-xs text-danger-ink bg-danger/10 border border-danger/20 rounded-cozy px-3 py-2">
                 {error}
               </div>
             )}
@@ -281,7 +281,7 @@ export default function TokenTemplateLibrary({ isOpen, onClose }: TokenTemplateL
                 </div>
               ) : templates.length === 0 ? (
                 <div className="text-center py-12 px-6">
-                  <Package className="w-8 h-8 text-moss-green/30 mx-auto mb-2" />
+                  <Package className="w-8 h-8 text-brand-ink/30 mx-auto mb-2" />
                   <p className="text-sm text-stone-gray/70">
                     {searchQuery ? 'No templates match your search.' : 'No saved token templates yet.'}
                   </p>
@@ -369,8 +369,8 @@ function TemplateRow({
   onCopyToCampaign,
 }: TemplateRowProps) {
   const typeColors: Record<string, string> = {
-    object: 'bg-amber-500/10 text-amber-600',
-    npc: 'bg-red-500/10 text-red-600',
+    object: 'bg-warning/10 text-warning-ink',
+    npc: 'bg-danger/10 text-danger-ink',
     player: 'bg-teal-500/10 text-teal-600',
   };
 
@@ -389,8 +389,8 @@ function TemplateRow({
           />
         ) : (
           <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 text-white font-bold text-sm ${
-            template.disposition === 'hostile' ? 'bg-red-500' :
-            template.disposition === 'friendly' ? 'bg-teal-500' : 'bg-amber-500'
+            template.disposition === 'hostile' ? 'bg-danger' :
+            template.disposition === 'friendly' ? 'bg-teal-500' : 'bg-warning'
           }`}>
             {template.name.charAt(0).toUpperCase()}
           </div>
@@ -421,14 +421,14 @@ function TemplateRow({
             <button
               onClick={onPlace}
               disabled={isPlacing}
-              className="flex-1 flex items-center justify-center gap-1.5 py-1.5 text-xs rounded-cozy bg-moss-green/10 text-moss-green border border-moss-green/30 hover:bg-moss-green/20 transition-colors font-medium"
+              className="flex-1 flex items-center justify-center gap-1.5 py-1.5 text-xs rounded-cozy bg-moss-green/10 text-brand-ink border border-moss-green/30 hover:bg-moss-green/20 transition-colors font-medium"
             >
               {isPlacing ? <Loader2 className="w-3 h-3 animate-spin" /> : <MapPin className="w-3 h-3" />}
               {isPlacing ? 'Placing...' : 'Place on Map'}
             </button>
             <button
               onClick={onEdit}
-              className="flex items-center gap-1 px-3 py-1.5 text-xs rounded-cozy border border-moss-green/20 text-moss-green hover:bg-moss-green/10 transition-colors"
+              className="flex items-center gap-1 px-3 py-1.5 text-xs rounded-cozy border border-moss-green/20 text-brand-ink hover:bg-moss-green/10 transition-colors"
               title="Edit template"
             >
               <Pencil className="w-3 h-3" /> Edit
@@ -465,7 +465,7 @@ function TemplateRow({
             </div>
             <button
               onClick={onDelete}
-              className="flex items-center gap-1 px-3 py-1.5 text-xs rounded-cozy border border-red-500/20 text-red-500 hover:bg-red-500/10 transition-colors"
+              className="flex items-center gap-1 px-3 py-1.5 text-xs rounded-cozy border border-danger/20 text-danger-ink hover:bg-danger/10 transition-colors"
             >
               <Trash2 className="w-3 h-3" /> Delete
             </button>
@@ -587,7 +587,7 @@ function TemplateForm({ campaignId, editingTemplate, onCreated, onEdited, onCanc
   return (
     <div className="border-t border-moss-green/20 bg-parchment/40 p-4 space-y-3 max-h-[60vh] overflow-y-auto">
       <div className="flex items-center justify-between">
-        <h3 className="text-xs font-semibold text-moss-green uppercase tracking-wide">
+        <h3 className="text-xs font-semibold text-brand-ink uppercase tracking-wide">
           {isEdit ? 'Edit Template' : 'New Token Template'}
         </h3>
         <button onClick={onCancel} className="text-stone-gray hover:text-stone-gray/80 p-0.5">
@@ -596,7 +596,7 @@ function TemplateForm({ campaignId, editingTemplate, onCreated, onEdited, onCanc
       </div>
 
       {formError && (
-        <div className="text-xs text-red-600 bg-red-500/10 rounded px-2 py-1">{formError}</div>
+        <div className="text-xs text-danger-ink bg-danger/10 rounded px-2 py-1">{formError}</div>
       )}
 
       {/* Name */}
@@ -620,11 +620,11 @@ function TemplateForm({ campaignId, editingTemplate, onCreated, onEdited, onCanc
             </div>
           )}
           <input ref={fileInputRef} type="file" accept="image/png,image/jpeg,image/webp,image/gif" onChange={handleImageUpload} className="hidden" />
-          <button type="button" onClick={() => fileInputRef.current?.click()} disabled={isUploading} className="text-[10px] text-moss-green hover:text-moss-green/80 flex items-center gap-1">
+          <button type="button" onClick={() => fileInputRef.current?.click()} disabled={isUploading} className="text-[10px] text-brand-ink hover:text-brand-ink/80 flex items-center gap-1">
             {isUploading ? <Loader2 className="w-3 h-3 animate-spin" /> : <Upload className="w-3 h-3" />}
             {imageUrl ? 'Change' : 'Upload'}
           </button>
-          {imageUrl && <button type="button" onClick={() => setImageUrl('')} className="text-[10px] text-red-500 hover:text-red-600">Remove</button>}
+          {imageUrl && <button type="button" onClick={() => setImageUrl('')} className="text-[10px] text-danger-ink hover:text-danger-ink">Remove</button>}
         </div>
       </div>
 
@@ -687,7 +687,7 @@ function TemplateForm({ campaignId, editingTemplate, onCreated, onEdited, onCanc
               if (!statBlock) setStatBlock(defaultStatBlockForNpc());
               setShowStatBlock((prev) => !prev);
             }}
-            className="flex items-center gap-1 w-full text-left py-1 text-[10px] font-semibold text-moss-green uppercase tracking-wide hover:text-moss-green/80 transition-colors"
+            className="flex items-center gap-1 w-full text-left py-1 text-[10px] font-semibold text-brand-ink uppercase tracking-wide hover:text-brand-ink/80 transition-colors"
           >
             {showStatBlock ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
             Stat Block
@@ -699,7 +699,7 @@ function TemplateForm({ campaignId, editingTemplate, onCreated, onEdited, onCanc
               <button
                 type="button"
                 onClick={() => { setStatBlock(null); setShowStatBlock(false); }}
-                className="mt-2 text-[10px] text-red-500 hover:text-red-600 flex items-center gap-1"
+                className="mt-2 text-[10px] text-danger-ink hover:text-danger-ink flex items-center gap-1"
               >
                 <Trash2 className="w-3 h-3" /> Clear stat block
               </button>

--- a/frontend/src/components/campaign/VibeTracker.tsx
+++ b/frontend/src/components/campaign/VibeTracker.tsx
@@ -67,13 +67,13 @@ export default function VibeTracker() {
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Sun className="w-4 h-4 text-warm-amber" />
-            <h3 className="text-sm font-semibold text-moss-green">Vibe Tracker</h3>
+            <h3 className="text-sm font-semibold text-brand-ink">Vibe Tracker</h3>
           </div>
 
           {userRole === 'DM' && (
             <button
               onClick={() => setIsConfigureOpen(true)}
-              className="p-1.5 rounded-lg hover:bg-moss-green/10 transition-colors text-stone-gray hover:text-moss-green"
+              className="p-1.5 rounded-lg hover:bg-moss-green/10 transition-colors text-stone-gray hover:text-brand-ink"
               title="Configure periods"
             >
               <Settings className="w-3.5 h-3.5" />
@@ -117,7 +117,7 @@ export default function VibeTracker() {
                     flex items-center gap-2 px-3 py-2 rounded-lg border text-left
                     transition-all duration-200 text-sm
                     ${isActive
-                      ? 'border-moss-green bg-moss-green/10 text-moss-green font-semibold ring-1 ring-moss-green/30'
+                      ? 'border-moss-green bg-moss-green/10 text-brand-ink font-semibold ring-1 ring-moss-green/30'
                       : 'border-moss-green/20 bg-parchment/40 text-stone-gray hover:bg-parchment/80 hover:border-moss-green/40'
                     }
                     disabled:opacity-50 disabled:cursor-not-allowed

--- a/frontend/src/components/campaign/npc-stat-blocks/Dnd5eStatBlock.tsx
+++ b/frontend/src/components/campaign/npc-stat-blocks/Dnd5eStatBlock.tsx
@@ -18,50 +18,50 @@ function abilityMod(score: number): string {
 
 export default function Dnd5eStatBlock({ statBlock, tokenName }: Props) {
   return (
-    <div className="space-y-2 text-xs text-stone-700">
+    <div className="space-y-2 text-xs text-ink">
       {/* ── Header ── */}
-      <div className="border-b-2 border-amber-700/40 pb-1.5">
-        <h3 className="text-sm font-bold text-amber-900">{tokenName}</h3>
-        <div className="italic text-stone-500">
+      <div className="border-b-2 border-warning/40 pb-1.5">
+        <h3 className="text-sm font-bold text-warning-ink">{tokenName}</h3>
+        <div className="italic text-ink-muted">
           {statBlock.creatureType || 'Creature'}
           {statBlock.alignment && `, ${statBlock.alignment}`}
         </div>
       </div>
 
       {/* ── Core stats ── */}
-      <div className="border-b border-amber-700/20 pb-1.5 space-y-0.5">
-        <div><span className="font-semibold text-amber-900">Armor Class</span> {statBlock.ac}</div>
+      <div className="border-b border-warning/20 pb-1.5 space-y-0.5">
+        <div><span className="font-semibold text-warning-ink">Armor Class</span> {statBlock.ac}</div>
         {statBlock.hpMax != null && (
           <div>
-            <span className="font-semibold text-amber-900">Hit Points</span> {statBlock.hpMax}
+            <span className="font-semibold text-warning-ink">Hit Points</span> {statBlock.hpMax}
             {statBlock.hitDice && ` (${statBlock.hitDice})`}
           </div>
         )}
-        <div><span className="font-semibold text-amber-900">Speed</span> {statBlock.speed}</div>
+        <div><span className="font-semibold text-warning-ink">Speed</span> {statBlock.speed}</div>
         {statBlock.challengeRating && (
           <div>
-            <span className="font-semibold text-amber-900">Challenge</span> {statBlock.challengeRating}
+            <span className="font-semibold text-warning-ink">Challenge</span> {statBlock.challengeRating}
             {statBlock.xp != null && ` (${statBlock.xp.toLocaleString()} XP)`}
           </div>
         )}
       </div>
 
       {/* ── Ability Scores ── */}
-      <div className="grid grid-cols-6 gap-1 text-center bg-amber-50/60 rounded p-1.5 border border-amber-700/10">
+      <div className="grid grid-cols-6 gap-1 text-center bg-warning/10 rounded p-1.5 border border-warning/10">
         {(['str', 'dex', 'con', 'int', 'wis', 'cha'] as const).map((ab) => (
           <div key={ab}>
-            <div className="text-[9px] font-bold text-amber-900 uppercase">{ab}</div>
+            <div className="text-[9px] font-bold text-warning-ink uppercase">{ab}</div>
             <div className="font-semibold">{statBlock.abilities[ab]}</div>
-            <div className="text-[10px] text-stone-500">({abilityMod(statBlock.abilities[ab])})</div>
+            <div className="text-[10px] text-ink-muted">({abilityMod(statBlock.abilities[ab])})</div>
           </div>
         ))}
       </div>
 
       {/* ── Detail lines ── */}
-      <div className="border-b border-amber-700/20 pb-1.5 space-y-0.5">
+      <div className="border-b border-warning/20 pb-1.5 space-y-0.5">
         {statBlock.savingThrows && Object.keys(statBlock.savingThrows).length > 0 && (
           <div>
-            <span className="font-semibold text-amber-900">Saving Throws</span>{' '}
+            <span className="font-semibold text-warning-ink">Saving Throws</span>{' '}
             {Object.entries(statBlock.savingThrows)
               .map(([k, v]) => `${k.charAt(0).toUpperCase() + k.slice(1)} +${v}`)
               .join(', ')}
@@ -69,29 +69,29 @@ export default function Dnd5eStatBlock({ statBlock, tokenName }: Props) {
         )}
         {statBlock.skills && Object.keys(statBlock.skills).length > 0 && (
           <div>
-            <span className="font-semibold text-amber-900">Skills</span>{' '}
+            <span className="font-semibold text-warning-ink">Skills</span>{' '}
             {Object.entries(statBlock.skills)
               .map(([k, v]) => `${k.charAt(0).toUpperCase() + k.slice(1)} +${v}`)
               .join(', ')}
           </div>
         )}
         {statBlock.damageVulnerabilities && (
-          <div><span className="font-semibold text-amber-900">Damage Vulnerabilities</span> {statBlock.damageVulnerabilities}</div>
+          <div><span className="font-semibold text-warning-ink">Damage Vulnerabilities</span> {statBlock.damageVulnerabilities}</div>
         )}
         {statBlock.damageResistances && (
-          <div><span className="font-semibold text-amber-900">Damage Resistances</span> {statBlock.damageResistances}</div>
+          <div><span className="font-semibold text-warning-ink">Damage Resistances</span> {statBlock.damageResistances}</div>
         )}
         {statBlock.damageImmunities && (
-          <div><span className="font-semibold text-amber-900">Damage Immunities</span> {statBlock.damageImmunities}</div>
+          <div><span className="font-semibold text-warning-ink">Damage Immunities</span> {statBlock.damageImmunities}</div>
         )}
         {statBlock.conditionImmunities && (
-          <div><span className="font-semibold text-amber-900">Condition Immunities</span> {statBlock.conditionImmunities}</div>
+          <div><span className="font-semibold text-warning-ink">Condition Immunities</span> {statBlock.conditionImmunities}</div>
         )}
         {statBlock.senses && (
-          <div><span className="font-semibold text-amber-900">Senses</span> {statBlock.senses}</div>
+          <div><span className="font-semibold text-warning-ink">Senses</span> {statBlock.senses}</div>
         )}
         {statBlock.languages && (
-          <div><span className="font-semibold text-amber-900">Languages</span> {statBlock.languages}</div>
+          <div><span className="font-semibold text-warning-ink">Languages</span> {statBlock.languages}</div>
         )}
       </div>
 
@@ -122,7 +122,7 @@ export default function Dnd5eStatBlock({ statBlock, tokenName }: Props) {
 
       {/* ── Notes ── */}
       {statBlock.notes && (
-        <div className="text-[10px] text-stone-500 italic border-t border-amber-700/20 pt-1.5">
+        <div className="text-[10px] text-ink-muted italic border-t border-warning/20 pt-1.5">
           {statBlock.notes}
         </div>
       )}
@@ -133,14 +133,14 @@ export default function Dnd5eStatBlock({ statBlock, tokenName }: Props) {
 function ActionSection({ title, items }: { title: string; items: Array<{ name: string; description: string }> }) {
   return (
     <div>
-      <div className="text-[10px] font-bold text-amber-900 uppercase tracking-wide border-b border-amber-700/20 pb-0.5 mb-1">
+      <div className="text-[10px] font-bold text-warning-ink uppercase tracking-wide border-b border-warning/20 pb-0.5 mb-1">
         {title}
       </div>
       <div className="space-y-1.5">
         {items.map((item, i) => (
           <div key={i} className="leading-snug">
-            <span className="font-semibold italic text-stone-800">{item.name}.</span>{' '}
-            <span className="text-stone-600">{item.description}</span>
+            <span className="font-semibold italic text-ink">{item.name}.</span>{' '}
+            <span className="text-ink-secondary">{item.description}</span>
           </div>
         ))}
       </div>

--- a/frontend/src/components/campaign/npc-stat-blocks/GenericStatBlock.tsx
+++ b/frontend/src/components/campaign/npc-stat-blocks/GenericStatBlock.tsx
@@ -18,11 +18,11 @@ function abilityMod(score: number): string {
 
 export default function GenericStatBlock({ statBlock, tokenName }: Props) {
   return (
-    <div className="space-y-2 text-xs text-stone-700">
+    <div className="space-y-2 text-xs text-ink">
       {/* Header */}
       <div className="border-b-2 border-moss-green/40 pb-1.5">
-        <h3 className="text-sm font-bold text-moss-green">{tokenName}</h3>
-        <div className="italic text-stone-500">
+        <h3 className="text-sm font-bold text-brand-ink">{tokenName}</h3>
+        <div className="italic text-ink-muted">
           {statBlock.creatureType || 'Creature'}
           {statBlock.alignment && `, ${statBlock.alignment}`}
         </div>
@@ -30,17 +30,17 @@ export default function GenericStatBlock({ statBlock, tokenName }: Props) {
 
       {/* Core stats */}
       <div className="flex gap-4 flex-wrap">
-        <div><span className="font-semibold text-moss-green">AC</span> {statBlock.ac}</div>
+        <div><span className="font-semibold text-brand-ink">AC</span> {statBlock.ac}</div>
         {statBlock.hpMax != null && (
           <div>
-            <span className="font-semibold text-moss-green">HP</span> {statBlock.hpMax}
+            <span className="font-semibold text-brand-ink">HP</span> {statBlock.hpMax}
             {statBlock.hitDice && ` (${statBlock.hitDice})`}
           </div>
         )}
-        <div><span className="font-semibold text-moss-green">Speed</span> {statBlock.speed}</div>
+        <div><span className="font-semibold text-brand-ink">Speed</span> {statBlock.speed}</div>
         {statBlock.challengeRating && (
           <div>
-            <span className="font-semibold text-moss-green">CR</span> {statBlock.challengeRating}
+            <span className="font-semibold text-brand-ink">CR</span> {statBlock.challengeRating}
             {statBlock.xp != null && ` (${statBlock.xp.toLocaleString()} XP)`}
           </div>
         )}
@@ -50,9 +50,9 @@ export default function GenericStatBlock({ statBlock, tokenName }: Props) {
       <div className="grid grid-cols-6 gap-1 text-center bg-moss-green/5 rounded p-1.5">
         {(['str', 'dex', 'con', 'int', 'wis', 'cha'] as const).map((ab) => (
           <div key={ab}>
-            <div className="text-[9px] font-bold text-moss-green uppercase">{ab}</div>
+            <div className="text-[9px] font-bold text-brand-ink uppercase">{ab}</div>
             <div className="font-semibold">{statBlock.abilities[ab]}</div>
-            <div className="text-[10px] text-stone-500">({abilityMod(statBlock.abilities[ab])})</div>
+            <div className="text-[10px] text-ink-muted">({abilityMod(statBlock.abilities[ab])})</div>
           </div>
         ))}
       </div>
@@ -68,7 +68,7 @@ export default function GenericStatBlock({ statBlock, tokenName }: Props) {
       {statBlock.legendaryActions?.length ? <ActionList title="Legendary Actions" items={statBlock.legendaryActions} /> : null}
 
       {statBlock.notes && (
-        <div className="text-[10px] text-stone-500 italic border-t border-moss-green/20 pt-1.5">
+        <div className="text-[10px] text-ink-muted italic border-t border-moss-green/20 pt-1.5">
           {statBlock.notes}
         </div>
       )}
@@ -98,7 +98,7 @@ function DetailLines({ statBlock }: { statBlock: NpcStatBlock }) {
     <div className="space-y-0.5 border-y border-moss-green/20 py-1.5">
       {entries.map(([label, value]) => (
         <div key={label}>
-          <span className="font-semibold text-moss-green">{label}</span> {value}
+          <span className="font-semibold text-brand-ink">{label}</span> {value}
         </div>
       ))}
     </div>
@@ -108,14 +108,14 @@ function DetailLines({ statBlock }: { statBlock: NpcStatBlock }) {
 function ActionList({ title, items }: { title: string; items: Array<{ name: string; description: string }> }) {
   return (
     <div>
-      <div className="text-[10px] font-bold text-moss-green uppercase tracking-wide border-b border-moss-green/20 pb-0.5 mb-1">
+      <div className="text-[10px] font-bold text-brand-ink uppercase tracking-wide border-b border-moss-green/20 pb-0.5 mb-1">
         {title}
       </div>
       <div className="space-y-1.5">
         {items.map((item, i) => (
           <div key={i} className="leading-snug">
-            <span className="font-semibold italic text-stone-800">{item.name}.</span>{' '}
-            <span className="text-stone-600">{item.description}</span>
+            <span className="font-semibold italic text-ink">{item.name}.</span>{' '}
+            <span className="text-ink-secondary">{item.description}</span>
           </div>
         ))}
       </div>

--- a/frontend/src/components/campaign/npc-stat-blocks/StatBlockEditor.tsx
+++ b/frontend/src/components/campaign/npc-stat-blocks/StatBlockEditor.tsx
@@ -78,7 +78,7 @@ export default function StatBlockEditor({ statBlock, onChange }: StatBlockEditor
         <div className="space-y-2 pl-1">
           <div className="grid grid-cols-2 gap-2">
             <div>
-              <label className="text-[10px] text-stone-500 block mb-0.5">Creature Type</label>
+              <label className="text-[10px] text-ink-muted block mb-0.5">Creature Type</label>
               <input
                 type="text"
                 value={statBlock.creatureType || ''}
@@ -88,7 +88,7 @@ export default function StatBlockEditor({ statBlock, onChange }: StatBlockEditor
               />
             </div>
             <div>
-              <label className="text-[10px] text-stone-500 block mb-0.5">Alignment</label>
+              <label className="text-[10px] text-ink-muted block mb-0.5">Alignment</label>
               <input
                 type="text"
                 value={statBlock.alignment || ''}
@@ -100,7 +100,7 @@ export default function StatBlockEditor({ statBlock, onChange }: StatBlockEditor
           </div>
           <div className="grid grid-cols-3 gap-2">
             <div>
-              <label className="text-[10px] text-stone-500 block mb-0.5">AC</label>
+              <label className="text-[10px] text-ink-muted block mb-0.5">AC</label>
               <input
                 type="number"
                 value={statBlock.ac}
@@ -109,7 +109,7 @@ export default function StatBlockEditor({ statBlock, onChange }: StatBlockEditor
               />
             </div>
             <div>
-              <label className="text-[10px] text-stone-500 block mb-0.5">CR</label>
+              <label className="text-[10px] text-ink-muted block mb-0.5">CR</label>
               <input
                 type="text"
                 value={statBlock.challengeRating || ''}
@@ -119,7 +119,7 @@ export default function StatBlockEditor({ statBlock, onChange }: StatBlockEditor
               />
             </div>
             <div>
-              <label className="text-[10px] text-stone-500 block mb-0.5">XP</label>
+              <label className="text-[10px] text-ink-muted block mb-0.5">XP</label>
               <input
                 type="number"
                 value={statBlock.xp ?? ''}
@@ -129,7 +129,7 @@ export default function StatBlockEditor({ statBlock, onChange }: StatBlockEditor
             </div>
           </div>
           <div>
-            <label className="text-[10px] text-stone-500 block mb-0.5">Speed</label>
+            <label className="text-[10px] text-ink-muted block mb-0.5">Speed</label>
             <input
               type="text"
               value={statBlock.speed}
@@ -147,7 +147,7 @@ export default function StatBlockEditor({ statBlock, onChange }: StatBlockEditor
         <div className="grid grid-cols-6 gap-1.5 pl-1">
           {(['str', 'dex', 'con', 'int', 'wis', 'cha'] as const).map((ab) => (
             <div key={ab} className="text-center">
-              <label className="text-[9px] font-bold text-moss-green uppercase block mb-0.5">{ab}</label>
+              <label className="text-[9px] font-bold text-brand-ink uppercase block mb-0.5">{ab}</label>
               <input
                 type="number"
                 value={statBlock.abilities[ab]}
@@ -191,7 +191,7 @@ export default function StatBlockEditor({ statBlock, onChange }: StatBlockEditor
             ['languages', 'Languages'],
           ] as const).map(([field, label]) => (
             <div key={field}>
-              <label className="text-[10px] text-stone-500 block mb-0.5">{label}</label>
+              <label className="text-[10px] text-ink-muted block mb-0.5">{label}</label>
               <input
                 type="text"
                 value={(statBlock[field] as string) || ''}
@@ -260,7 +260,7 @@ function SectionHeader({
     <button
       type="button"
       onClick={() => toggle(section)}
-      className="flex items-center gap-1 w-full text-left py-1 text-[10px] font-semibold text-moss-green uppercase tracking-wide hover:text-moss-green/80 transition-colors"
+      className="flex items-center gap-1 w-full text-left py-1 text-[10px] font-semibold text-brand-ink uppercase tracking-wide hover:text-brand-ink/80 transition-colors"
     >
       {expanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
       {title}
@@ -291,10 +291,10 @@ function KeyValueEditor({
 
   return (
     <div>
-      <label className="text-[10px] text-stone-500 block mb-0.5">{label}</label>
+      <label className="text-[10px] text-ink-muted block mb-0.5">{label}</label>
       {Object.entries(entries).map(([key, val]) => (
         <div key={key} className="flex items-center gap-1 mb-0.5">
-          <span className="text-[10px] text-stone-600 w-20 capitalize">{key}</span>
+          <span className="text-[10px] text-ink-secondary w-20 capitalize">{key}</span>
           <input
             type="number"
             value={val}
@@ -304,7 +304,7 @@ function KeyValueEditor({
           <button
             type="button"
             onClick={() => onUpdate(key, null)}
-            className="p-0.5 text-stone-400 hover:text-red-500 transition-colors"
+            className="p-0.5 text-ink-muted hover:text-danger-ink transition-colors"
             title="Remove"
           >
             <X className="w-3 h-3" />
@@ -323,7 +323,7 @@ function KeyValueEditor({
         <button
           type="button"
           onClick={handleAdd}
-          className="p-1 text-moss-green hover:text-moss-green/80 transition-colors"
+          className="p-1 text-brand-ink hover:text-brand-ink/80 transition-colors"
           title="Add"
         >
           <Plus className="w-3 h-3" />
@@ -374,7 +374,7 @@ function ActionListEditor({
           <button
             type="button"
             onClick={() => removeItem(i)}
-            className="p-1 mt-1 text-stone-400 hover:text-red-500 transition-colors flex-shrink-0"
+            className="p-1 mt-1 text-ink-muted hover:text-danger-ink transition-colors flex-shrink-0"
             title="Remove"
           >
             <X className="w-3 h-3" />
@@ -384,7 +384,7 @@ function ActionListEditor({
       <button
         type="button"
         onClick={addItem}
-        className="flex items-center gap-1 text-[10px] text-moss-green hover:text-moss-green/80 transition-colors"
+        className="flex items-center gap-1 text-[10px] text-brand-ink hover:text-brand-ink/80 transition-colors"
       >
         <Plus className="w-3 h-3" /> Add entry
       </button>

--- a/frontend/src/components/campaign/npc-stat-blocks/StatBlockViewer.tsx
+++ b/frontend/src/components/campaign/npc-stat-blocks/StatBlockViewer.tsx
@@ -39,45 +39,45 @@ function Pf2eStatBlock({ statBlock, tokenName }: { statBlock: NpcStatBlock; toke
   return (
     <div className="space-y-2 text-xs">
       {/* Header */}
-      <div className="border-b-2 border-red-700/40 pb-1.5">
-        <h3 className="text-sm font-bold text-red-800">{tokenName}</h3>
-        <div className="flex gap-3 text-stone-600">
+      <div className="border-b-2 border-danger/40 pb-1.5">
+        <h3 className="text-sm font-bold text-danger-ink">{tokenName}</h3>
+        <div className="flex gap-3 text-ink-secondary">
           {statBlock.creatureType && <span>{statBlock.creatureType}</span>}
           {statBlock.alignment && <span className="italic">{statBlock.alignment}</span>}
         </div>
       </div>
 
       {/* Key stats */}
-      <div className="flex gap-4 flex-wrap text-stone-700">
+      <div className="flex gap-4 flex-wrap text-ink">
         {statBlock.challengeRating && (
-          <div><span className="font-semibold text-red-800">Level</span> {statBlock.challengeRating}</div>
+          <div><span className="font-semibold text-danger-ink">Level</span> {statBlock.challengeRating}</div>
         )}
-        <div><span className="font-semibold text-red-800">AC</span> {statBlock.ac}</div>
+        <div><span className="font-semibold text-danger-ink">AC</span> {statBlock.ac}</div>
         {statBlock.hpMax != null && (
           <div>
-            <span className="font-semibold text-red-800">HP</span> {statBlock.hpMax}
+            <span className="font-semibold text-danger-ink">HP</span> {statBlock.hpMax}
             {statBlock.hitDice && ` (${statBlock.hitDice})`}
           </div>
         )}
-        <div><span className="font-semibold text-red-800">Speed</span> {statBlock.speed}</div>
+        <div><span className="font-semibold text-danger-ink">Speed</span> {statBlock.speed}</div>
       </div>
 
       {/* Abilities */}
-      <div className="grid grid-cols-6 gap-1 text-center bg-red-50/50 rounded p-1.5">
+      <div className="grid grid-cols-6 gap-1 text-center bg-danger/10 rounded p-1.5">
         {(['str', 'dex', 'con', 'int', 'wis', 'cha'] as const).map((ab) => (
           <div key={ab}>
-            <div className="text-[9px] font-bold text-red-800 uppercase">{ab}</div>
-            <div className="text-stone-700">{statBlock.abilities[ab]}</div>
-            <div className="text-[10px] text-stone-500">{mod(statBlock.abilities[ab])}</div>
+            <div className="text-[9px] font-bold text-danger-ink uppercase">{ab}</div>
+            <div className="text-ink">{statBlock.abilities[ab]}</div>
+            <div className="text-[10px] text-ink-muted">{mod(statBlock.abilities[ab])}</div>
           </div>
         ))}
       </div>
 
       {/* Defenses & senses */}
-      <StatBlockDetailLines statBlock={statBlock} accentColor="red" />
+      <StatBlockDetailLines statBlock={statBlock} accentColor="danger" />
 
       {/* Abilities and actions */}
-      <StatBlockActionSections statBlock={statBlock} accentColor="red" />
+      <StatBlockActionSections statBlock={statBlock} accentColor="danger" />
     </div>
   );
 }
@@ -87,46 +87,62 @@ function CoCStatBlock({ statBlock, tokenName }: { statBlock: NpcStatBlock; token
   return (
     <div className="space-y-2 text-xs">
       {/* Header */}
-      <div className="border-b-2 border-emerald-700/40 pb-1.5">
-        <h3 className="text-sm font-bold text-emerald-800">{tokenName}</h3>
+      <div className="border-b-2 border-success/40 pb-1.5">
+        <h3 className="text-sm font-bold text-success-ink">{tokenName}</h3>
         {statBlock.creatureType && (
-          <div className="text-stone-600 italic">{statBlock.creatureType}</div>
+          <div className="text-ink-secondary italic">{statBlock.creatureType}</div>
         )}
       </div>
 
       {/* Characteristics — CoC uses STR/CON/SIZ/DEX/INT/POW/APP/EDU */}
-      <div className="grid grid-cols-6 gap-1 text-center bg-emerald-50/50 rounded p-1.5">
+      <div className="grid grid-cols-6 gap-1 text-center bg-success/10 rounded p-1.5">
         {(['str', 'dex', 'con', 'int', 'wis', 'cha'] as const).map((ab) => {
           // Map D&D ability names to CoC equivalents for display
           const cocLabel = ab === 'wis' ? 'POW' : ab === 'cha' ? 'APP' : ab.toUpperCase();
           return (
             <div key={ab}>
-              <div className="text-[9px] font-bold text-emerald-800 uppercase">{cocLabel}</div>
-              <div className="text-stone-700">{statBlock.abilities[ab]}</div>
+              <div className="text-[9px] font-bold text-success-ink uppercase">{cocLabel}</div>
+              <div className="text-ink">{statBlock.abilities[ab]}</div>
             </div>
           );
         })}
       </div>
 
       {/* Combat stats */}
-      <div className="flex gap-4 flex-wrap text-stone-700">
-        <div><span className="font-semibold text-emerald-800">Armor</span> {statBlock.ac}</div>
+      <div className="flex gap-4 flex-wrap text-ink">
+        <div><span className="font-semibold text-success-ink">Armor</span> {statBlock.ac}</div>
         {statBlock.hpMax != null && (
-          <div><span className="font-semibold text-emerald-800">HP</span> {statBlock.hpMax}</div>
+          <div><span className="font-semibold text-success-ink">HP</span> {statBlock.hpMax}</div>
         )}
-        <div><span className="font-semibold text-emerald-800">Move</span> {statBlock.speed}</div>
+        <div><span className="font-semibold text-success-ink">Move</span> {statBlock.speed}</div>
       </div>
 
-      <StatBlockDetailLines statBlock={statBlock} accentColor="emerald" />
-      <StatBlockActionSections statBlock={statBlock} accentColor="emerald" />
+      <StatBlockDetailLines statBlock={statBlock} accentColor="success" />
+      <StatBlockActionSections statBlock={statBlock} accentColor="success" />
     </div>
   );
 }
 
 // ─── Shared sub-components ───────────────────────────────────────
 
-function StatBlockDetailLines({ statBlock, accentColor }: { statBlock: NpcStatBlock; accentColor: string }) {
-  const accent = `text-${accentColor}-800`;
+/**
+ * Per-system accent classes.
+ *
+ * Written out in full because Tailwind only ships classes it can find as
+ * literal strings — the previous `text-${accentColor}-800` template produced
+ * class names that were never generated, so the accent silently did nothing.
+ */
+const ACCENTS = {
+  danger: { text: 'text-danger-ink', border: 'border-danger/20' },
+  success: { text: 'text-success-ink', border: 'border-success/20' },
+  warning: { text: 'text-warning-ink', border: 'border-warning/20' },
+  brand: { text: 'text-brand-ink', border: 'border-brand/20' },
+} as const;
+
+type AccentName = keyof typeof ACCENTS;
+
+function StatBlockDetailLines({ statBlock, accentColor }: { statBlock: NpcStatBlock; accentColor: AccentName }) {
+  const accent = ACCENTS[accentColor].text;
   const lines: Array<{ label: string; value: string }> = [];
 
   if (statBlock.savingThrows && Object.keys(statBlock.savingThrows).length > 0) {
@@ -155,7 +171,7 @@ function StatBlockDetailLines({ statBlock, accentColor }: { statBlock: NpcStatBl
   if (lines.length === 0) return null;
 
   return (
-    <div className="space-y-0.5 text-stone-700">
+    <div className="space-y-0.5 text-ink">
       {lines.map(({ label, value }) => (
         <div key={label}>
           <span className={`font-semibold ${accent}`}>{label}</span> {value}
@@ -165,7 +181,7 @@ function StatBlockDetailLines({ statBlock, accentColor }: { statBlock: NpcStatBl
   );
 }
 
-function StatBlockActionSections({ statBlock, accentColor }: { statBlock: NpcStatBlock; accentColor: string }) {
+function StatBlockActionSections({ statBlock, accentColor }: { statBlock: NpcStatBlock; accentColor: AccentName }) {
   const sections: Array<{ title: string; items: Array<{ name: string; description: string }> }> = [];
 
   if (statBlock.traits?.length) sections.push({ title: 'Traits', items: statBlock.traits });
@@ -180,14 +196,14 @@ function StatBlockActionSections({ statBlock, accentColor }: { statBlock: NpcSta
     <>
       {sections.map(({ title, items }) => (
         <div key={title}>
-          <div className={`text-[10px] font-bold text-${accentColor}-800 uppercase tracking-wide border-b border-${accentColor}-700/20 pb-0.5 mb-1`}>
+          <div className={`text-[10px] font-bold ${ACCENTS[accentColor].text} uppercase tracking-wide border-b ${ACCENTS[accentColor].border} pb-0.5 mb-1`}>
             {title}
           </div>
           <div className="space-y-1">
             {items.map((item, i) => (
               <div key={i}>
-                <span className="font-semibold italic text-stone-800">{item.name}.</span>{' '}
-                <span className="text-stone-600">{item.description}</span>
+                <span className="font-semibold italic text-ink">{item.name}.</span>{' '}
+                <span className="text-ink-secondary">{item.description}</span>
               </div>
             ))}
           </div>

--- a/frontend/src/components/character-sheets/LoadingSpinner.tsx
+++ b/frontend/src/components/character-sheets/LoadingSpinner.tsx
@@ -7,7 +7,7 @@ import { Loader2 } from 'lucide-react';
 export const CharacterSheetLoadingSpinner: React.FC = () => {
   return (
     <div className="flex flex-col items-center justify-center py-12 space-y-4">
-      <Loader2 className="w-8 h-8 text-moss-green animate-spin" />
+      <Loader2 className="w-8 h-8 text-brand-ink animate-spin" />
       <p className="text-sm text-stone-gray">Loading character sheet...</p>
     </div>
   );

--- a/frontend/src/components/character-sheets/dnd5e/DnD5eCharacterEditor.tsx
+++ b/frontend/src/components/character-sheets/dnd5e/DnD5eCharacterEditor.tsx
@@ -1450,7 +1450,7 @@ export const DnD5eCharacterEditor: React.FC<DnD5eCharacterEditorProps> = ({
         <div className="grid grid-cols-5 gap-3">
           {[
             { key: 'cp', label: 'Copper (CP)', color: 'text-amber-700' },
-            { key: 'sp', label: 'Silver (SP)', color: 'text-stone-400' },
+            { key: 'sp', label: 'Silver (SP)', color: 'text-stone-500' },
             { key: 'ep', label: 'Electrum (EP)', color: 'text-green-600' },
             { key: 'gp', label: 'Gold (GP)', color: 'text-yellow-600' },
             { key: 'pp', label: 'Platinum (PP)', color: 'text-slate-300' },

--- a/frontend/src/components/character-sheets/dnd5e/DnD5eCharacterView.tsx
+++ b/frontend/src/components/character-sheets/dnd5e/DnD5eCharacterView.tsx
@@ -460,7 +460,7 @@ export const DnD5eCharacterView: React.FC<DnD5eCharacterViewProps> = ({ characte
         <SpellcastingBlock spellcasting={data.spellcasting} />
       ) : (
         <div className="text-center py-12 text-stone-500">
-          <Sparkles className="w-12 h-12 mx-auto mb-3 text-stone-400" />
+          <Sparkles className="w-12 h-12 mx-auto mb-3 text-stone-500" />
           <p>This character is not a spellcaster</p>
         </div>
       )}

--- a/frontend/src/components/character-sheets/dnd5e/components/InventoryList.tsx
+++ b/frontend/src/components/character-sheets/dnd5e/components/InventoryList.tsx
@@ -71,7 +71,7 @@ const InventoryItemRow: React.FC<{ item: InventoryItem }> = ({ item }) => {
     <div className="flex items-center justify-between p-2 hover:bg-stone-50 rounded border-b border-stone-100 last:border-0">
       <div className="flex-1">
         <div className="flex items-center space-x-2">
-          <Package className="w-4 h-4 text-stone-400" />
+          <Package className="w-4 h-4 text-stone-500" />
           <div>
             <div className="flex items-center flex-wrap gap-2">
               <span className="font-medium text-stone-800">{item.name}</span>
@@ -100,11 +100,11 @@ const InventoryItemRow: React.FC<{ item: InventoryItem }> = ({ item }) => {
       </div>
       <div className="flex items-center space-x-4 text-sm text-stone-600">
         <div className="text-right">
-          <div className="text-xs text-stone-400">Qty</div>
+          <div className="text-xs text-stone-500">Qty</div>
           <div>{item.quantity}</div>
         </div>
         <div className="text-right">
-          <div className="text-xs text-stone-400">Wt</div>
+          <div className="text-xs text-stone-500">Wt</div>
           <div>{item.weight} lb</div>
         </div>
       </div>

--- a/frontend/src/components/character-sheets/dnd5e/components/SkillsList.tsx
+++ b/frontend/src/components/character-sheets/dnd5e/components/SkillsList.tsx
@@ -82,7 +82,7 @@ const SkillRow: React.FC<{
     } else if (skill.proficient) {
       return <CheckCircle2 className="w-4 h-4 text-red-700" />;
     } else {
-      return <Circle className="w-4 h-4 text-stone-400" />;
+      return <Circle className="w-4 h-4 text-stone-500" />;
     }
   };
 
@@ -146,7 +146,7 @@ export const SkillsList: React.FC<SkillsListProps> = ({ skills, passivePerceptio
       <div className="mt-3 pt-3 border-t border-stone-200">
         <div className="flex flex-wrap gap-4 text-xs text-stone-600">
           <div className="flex items-center space-x-1">
-            <Circle className="w-3 h-3 text-stone-400" />
+            <Circle className="w-3 h-3 text-stone-500" />
             <span>Not Proficient</span>
           </div>
           <div className="flex items-center space-x-1">

--- a/frontend/src/components/character-sheets/dnd5e/components/SpellcastingBlock.tsx
+++ b/frontend/src/components/character-sheets/dnd5e/components/SpellcastingBlock.tsx
@@ -57,7 +57,7 @@ const SpellSlotIndicator: React.FC<{ slot: SpellSlot }> = ({ slot }) => {
           {idx < remaining ? (
             <CircleDot className="w-3 h-3 text-blue-600" />
           ) : (
-            <Circle className="w-3 h-3 text-stone-300" />
+            <Circle className="w-3 h-3 text-stone-500" />
           )}
         </div>
       ))}
@@ -78,7 +78,7 @@ const SpellRow: React.FC<{ spell: Spell }> = ({ spell }) => {
         {spell.prepared ? (
           <BookOpen className="w-4 h-4 text-blue-600" />
         ) : (
-          <BookOpen className="w-4 h-4 text-stone-300" />
+          <BookOpen className="w-4 h-4 text-stone-500" />
         )}
         <span className={`text-sm ${spell.prepared ? 'text-stone-800 font-medium' : 'text-stone-500'}`}>
           {spell.name}

--- a/frontend/src/components/character-sheets/flexible/FlexibleCharacterSheetEdit.tsx
+++ b/frontend/src/components/character-sheets/flexible/FlexibleCharacterSheetEdit.tsx
@@ -172,7 +172,7 @@ export const FlexibleCharacterSheetEdit: React.FC<FlexibleCharacterSheetEditProp
                 />
               ) : (
                 <div className="w-16 h-16 rounded-full border-2 border-moss-green/30 bg-moss-green/10 flex items-center justify-center">
-                  <User className="w-8 h-8 text-moss-green/40" />
+                  <User className="w-8 h-8 text-brand-ink/40" />
                 </div>
               )}
               <div className="absolute inset-0 rounded-full bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
@@ -192,7 +192,7 @@ export const FlexibleCharacterSheetEdit: React.FC<FlexibleCharacterSheetEditProp
           </div>
 
           <div>
-            <h2 className="text-2xl font-bold text-moss-green">
+            <h2 className="text-2xl font-bold text-brand-ink">
               Editing: {character.name}
             </h2>
             <p className="text-sm text-stone-gray">
@@ -239,7 +239,7 @@ export const FlexibleCharacterSheetEdit: React.FC<FlexibleCharacterSheetEditProp
       <div className="relative">
         <button
           onClick={() => setShowAddMenu(!showAddMenu)}
-          className="flex items-center gap-2 px-4 py-2 bg-moss-green/10 text-moss-green rounded-lg hover:bg-moss-green/20 transition-colors w-full justify-center"
+          className="flex items-center gap-2 px-4 py-2 bg-moss-green/10 text-brand-ink rounded-lg hover:bg-moss-green/20 transition-colors w-full justify-center"
         >
           <Plus className="w-4 h-4" />
           Add Section

--- a/frontend/src/components/character-sheets/flexible/FlexibleCharacterSheetView.tsx
+++ b/frontend/src/components/character-sheets/flexible/FlexibleCharacterSheetView.tsx
@@ -78,11 +78,11 @@ export const FlexibleCharacterSheetView: React.FC<FlexibleCharacterSheetViewProp
             />
           ) : (
             <div className="p-2 rounded-lg bg-moss-green/10">
-              <User className="w-6 h-6 text-moss-green" />
+              <User className="w-6 h-6 text-brand-ink" />
             </div>
           )}
           <div>
-            <h2 className="text-2xl font-bold text-moss-green">{character.name}</h2>
+            <h2 className="text-2xl font-bold text-brand-ink">{character.name}</h2>
             <p className="text-sm text-stone-gray">Flexible Character Sheet</p>
           </div>
         </div>

--- a/frontend/src/components/character-sheets/flexible/components/AddSectionMenu.tsx
+++ b/frontend/src/components/character-sheets/flexible/components/AddSectionMenu.tsx
@@ -64,10 +64,10 @@ export const AddSectionMenu: React.FC<AddSectionMenuProps> = ({ onSelect, onClos
       >
         <div className="flex items-start gap-3">
           <div className="flex-shrink-0 p-2 rounded bg-moss-green/10 group-hover:bg-moss-green/20 transition-colors">
-            <Icon className="w-5 h-5 text-moss-green" />
+            <Icon className="w-5 h-5 text-brand-ink" />
           </div>
           <div className="flex-1 min-w-0">
-            <div className="font-semibold text-moss-green">{template.name}</div>
+            <div className="font-semibold text-brand-ink">{template.name}</div>
             <div className="text-sm text-stone-gray">{template.description}</div>
           </div>
         </div>

--- a/frontend/src/components/character-sheets/flexible/components/SectionEditor.tsx
+++ b/frontend/src/components/character-sheets/flexible/components/SectionEditor.tsx
@@ -35,7 +35,7 @@ export const SectionEditor: React.FC<SectionEditorProps> = ({
           type="text"
           value={section.title}
           onChange={(e) => updateTitle(e.target.value)}
-          className="flex-1 text-lg font-semibold bg-transparent border-b border-transparent focus:border-moss-green focus:outline-none text-moss-green"
+          className="flex-1 text-lg font-semibold bg-transparent border-b border-transparent focus:border-moss-green focus:outline-none text-brand-ink"
           placeholder="Section title"
         />
 

--- a/frontend/src/components/character-sheets/flexible/components/SectionHeader.tsx
+++ b/frontend/src/components/character-sheets/flexible/components/SectionHeader.tsx
@@ -25,7 +25,7 @@ export const SectionHeader: React.FC<SectionHeaderProps> = ({
       }`}
       onClick={showToggle && onToggle ? onToggle : undefined}
     >
-      <h3 className="text-lg font-semibold text-moss-green">{title}</h3>
+      <h3 className="text-lg font-semibold text-brand-ink">{title}</h3>
       {showToggle && onToggle && (
         <button
           type="button"
@@ -33,9 +33,9 @@ export const SectionHeader: React.FC<SectionHeaderProps> = ({
           aria-label={isCollapsed ? 'Expand section' : 'Collapse section'}
         >
           {isCollapsed ? (
-            <ChevronDown className="w-5 h-5 text-moss-green" />
+            <ChevronDown className="w-5 h-5 text-brand-ink" />
           ) : (
-            <ChevronUp className="w-5 h-5 text-moss-green" />
+            <ChevronUp className="w-5 h-5 text-brand-ink" />
           )}
         </button>
       )}

--- a/frontend/src/components/character-sheets/flexible/components/sections/ListDisplay.tsx
+++ b/frontend/src/components/character-sheets/flexible/components/sections/ListDisplay.tsx
@@ -30,7 +30,7 @@ export const ListDisplay: React.FC<ListDisplayProps> = ({ section }) => {
             {item.checked !== undefined && (
               <div className="flex-shrink-0 mt-0.5">
                 {item.checked ? (
-                  <CheckCircle2 className="w-5 h-5 text-moss-green" />
+                  <CheckCircle2 className="w-5 h-5 text-brand-ink" />
                 ) : (
                   <Circle className="w-5 h-5 text-stone-gray" />
                 )}

--- a/frontend/src/components/character-sheets/flexible/components/sections/ListEditor.tsx
+++ b/frontend/src/components/character-sheets/flexible/components/sections/ListEditor.tsx
@@ -55,7 +55,7 @@ export const ListEditor: React.FC<ListEditorProps> = ({ section, onUpdate }) => 
                   className="flex-shrink-0"
                 >
                   {item.checked ? (
-                    <CheckSquare className="w-5 h-5 text-moss-green" />
+                    <CheckSquare className="w-5 h-5 text-brand-ink" />
                   ) : (
                     <Square className="w-5 h-5 text-stone-gray" />
                   )}
@@ -88,7 +88,7 @@ export const ListEditor: React.FC<ListEditorProps> = ({ section, onUpdate }) => 
 
       <button
         onClick={addItem}
-        className="flex items-center gap-2 px-4 py-2 bg-moss-green/10 text-moss-green rounded-lg hover:bg-moss-green/20 transition-colors w-full justify-center"
+        className="flex items-center gap-2 px-4 py-2 bg-moss-green/10 text-brand-ink rounded-lg hover:bg-moss-green/20 transition-colors w-full justify-center"
       >
         <Plus className="w-4 h-4" />
         Add Item

--- a/frontend/src/components/character-sheets/flexible/components/sections/StatsDisplay.tsx
+++ b/frontend/src/components/character-sheets/flexible/components/sections/StatsDisplay.tsx
@@ -29,7 +29,7 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({ section }) => {
           >
             <div className="text-sm text-stone-gray mb-1">{field.name}</div>
             <div className="flex items-baseline gap-2">
-              <span className="text-2xl font-bold text-moss-green">{field.value}</span>
+              <span className="text-2xl font-bold text-brand-ink">{field.value}</span>
               {field.modifier !== undefined && (
                 <span className="text-lg text-stone-gray">
                   ({formatModifier(field.modifier)})

--- a/frontend/src/components/character-sheets/flexible/components/sections/StatsEditor.tsx
+++ b/frontend/src/components/character-sheets/flexible/components/sections/StatsEditor.tsx
@@ -65,7 +65,7 @@ export const StatsEditor: React.FC<StatsEditorProps> = ({ section, onUpdate }) =
                 type="text"
                 value={field.name}
                 onChange={(e) => updateField(field.id, { name: e.target.value })}
-                className="w-full text-sm font-semibold bg-transparent border-b border-moss-green/30 focus:border-moss-green focus:outline-none text-moss-green"
+                className="w-full text-sm font-semibold bg-transparent border-b border-moss-green/30 focus:border-moss-green focus:outline-none text-brand-ink"
                 placeholder="Stat name"
               />
 
@@ -76,7 +76,7 @@ export const StatsEditor: React.FC<StatsEditorProps> = ({ section, onUpdate }) =
                   onChange={(e) =>
                     updateField(field.id, { value: parseInt(e.target.value) || 0 })
                   }
-                  className="w-20 text-2xl font-bold bg-transparent border-b border-moss-green/30 focus:border-moss-green focus:outline-none text-moss-green"
+                  className="w-20 text-2xl font-bold bg-transparent border-b border-moss-green/30 focus:border-moss-green focus:outline-none text-brand-ink"
                 />
                 <span className="text-lg text-stone-gray">
                   ({formatModifier(field.modifier || 0)})
@@ -89,7 +89,7 @@ export const StatsEditor: React.FC<StatsEditorProps> = ({ section, onUpdate }) =
 
       <button
         onClick={addField}
-        className="flex items-center gap-2 px-4 py-2 bg-moss-green/10 text-moss-green rounded-lg hover:bg-moss-green/20 transition-colors w-full justify-center"
+        className="flex items-center gap-2 px-4 py-2 bg-moss-green/10 text-brand-ink rounded-lg hover:bg-moss-green/20 transition-colors w-full justify-center"
       >
         <Plus className="w-4 h-4" />
         Add Stat

--- a/frontend/src/components/character-sheets/flexible/components/sections/TableDisplay.tsx
+++ b/frontend/src/components/character-sheets/flexible/components/sections/TableDisplay.tsx
@@ -26,7 +26,7 @@ export const TableDisplay: React.FC<TableDisplayProps> = ({ section }) => {
             {section.columns.map((column) => (
               <th
                 key={column.id}
-                className="px-4 py-2 text-left text-sm font-semibold text-moss-green"
+                className="px-4 py-2 text-left text-sm font-semibold text-brand-ink"
                 style={{ width: column.width }}
               >
                 {column.name}

--- a/frontend/src/components/character-sheets/flexible/components/sections/TableEditor.tsx
+++ b/frontend/src/components/character-sheets/flexible/components/sections/TableEditor.tsx
@@ -77,7 +77,7 @@ export const TableEditor: React.FC<TableEditorProps> = ({ section, onUpdate }) =
                     type="text"
                     value={column.name}
                     onChange={(e) => updateColumnName(column.id, e.target.value)}
-                    className="flex-1 bg-transparent border-b border-moss-green/30 focus:border-moss-green focus:outline-none text-sm font-semibold text-moss-green"
+                    className="flex-1 bg-transparent border-b border-moss-green/30 focus:border-moss-green focus:outline-none text-sm font-semibold text-brand-ink"
                     placeholder="Column name"
                   />
                   {section.columns.length > 1 && (
@@ -95,7 +95,7 @@ export const TableEditor: React.FC<TableEditorProps> = ({ section, onUpdate }) =
             <th className="px-2 py-2 w-12">
               <button
                 onClick={addColumn}
-                className="p-1 rounded bg-moss-green/10 text-moss-green hover:bg-moss-green/20"
+                className="p-1 rounded bg-moss-green/10 text-brand-ink hover:bg-moss-green/20"
                 title="Add column"
               >
                 <Plus className="w-4 h-4" />
@@ -138,7 +138,7 @@ export const TableEditor: React.FC<TableEditorProps> = ({ section, onUpdate }) =
 
       <button
         onClick={addRow}
-        className="flex items-center gap-2 px-4 py-2 bg-moss-green/10 text-moss-green rounded-lg hover:bg-moss-green/20 transition-colors w-full justify-center"
+        className="flex items-center gap-2 px-4 py-2 bg-moss-green/10 text-brand-ink rounded-lg hover:bg-moss-green/20 transition-colors w-full justify-center"
       >
         <Plus className="w-4 h-4" />
         Add Row

--- a/frontend/src/components/character-sheets/pathfinder2e/Pathfinder2eCharacterView.tsx
+++ b/frontend/src/components/character-sheets/pathfinder2e/Pathfinder2eCharacterView.tsx
@@ -725,7 +725,7 @@ export const Pathfinder2eCharacterView: React.FC<Pathfinder2eCharacterViewProps>
                     {formatSpellRank(rank)}
                   </div>
                   <div className="text-center">
-                    <span className={`text-lg font-bold ${remaining > 0 ? 'text-purple-700' : 'text-stone-400'}`}>
+                    <span className={`text-lg font-bold ${remaining > 0 ? 'text-purple-700' : 'text-stone-500'}`}>
                       {remaining}
                     </span>
                     <span className="text-xs text-stone-500"> / {slot.total}</span>

--- a/frontend/src/components/character/AssignCharacterModal.tsx
+++ b/frontend/src/components/character/AssignCharacterModal.tsx
@@ -113,7 +113,7 @@ export default function AssignCharacterModal({
       <div className="space-y-4">
                 {/* Character Info */}
                 <div className="glass-panel p-4">
-                  <h3 className="font-semibold text-moss-green mb-2">Character</h3>
+                  <h3 className="font-semibold text-brand-ink mb-2">Character</h3>
                   <div className="flex items-center gap-3">
                     <div className="w-12 h-12 rounded-lg bg-moss-green/10 border-2 border-moss-green/30
                                   flex items-center justify-center overflow-hidden flex-shrink-0">
@@ -124,7 +124,7 @@ export default function AssignCharacterModal({
                           className="w-full h-full object-cover"
                         />
                       ) : (
-                        <span className="text-lg font-bold text-moss-green">
+                        <span className="text-lg font-bold text-brand-ink">
                           {character.name.charAt(0).toUpperCase()}
                         </span>
                       )}
@@ -157,7 +157,7 @@ export default function AssignCharacterModal({
 
                   {loadingCampaigns ? (
                     <div className="flex items-center justify-center py-8">
-                      <Loader2 className="w-6 h-6 text-moss-green animate-spin" />
+                      <Loader2 className="w-6 h-6 text-brand-ink animate-spin" />
                     </div>
                   ) : compatibleCampaigns.length === 0 ? (
                     <div className="bg-warm-amber/10 border border-warm-amber/30 rounded-lg p-4">
@@ -242,7 +242,7 @@ export default function AssignCharacterModal({
                 {character.gameSystem && (
                   <div className="bg-moss-green/10 border border-moss-green/30 rounded-lg p-3">
                     <p className="text-xs text-stone-gray">
-                      <strong className="text-moss-green">Note:</strong> Only showing campaigns
+                      <strong className="text-brand-ink">Note:</strong> Only showing campaigns
                       compatible with {character.gameSystem} or flexible campaigns.
                     </p>
                   </div>

--- a/frontend/src/components/character/CharacterCard.tsx
+++ b/frontend/src/components/character/CharacterCard.tsx
@@ -186,13 +186,13 @@ function CharacterCardInner({
                 className="w-full h-full object-cover"
               />
             ) : (
-              <User className="w-8 h-8 text-moss-green" />
+              <User className="w-8 h-8 text-brand-ink" />
             )}
           </div>
 
           <div className="flex-1 min-w-0 pr-8">
             {/* Character Name */}
-            <h3 className="text-xl font-semibold text-moss-green mb-1 truncate
+            <h3 className="text-xl font-semibold text-brand-ink mb-1 truncate
                          group-hover:text-spirit-purple transition-colors">
               {character.name}
             </h3>

--- a/frontend/src/components/character/CharacterSheetViewerModal.tsx
+++ b/frontend/src/components/character/CharacterSheetViewerModal.tsx
@@ -160,10 +160,10 @@ export default function CharacterSheetViewerModal({
           <div className="flex-1">
             <div className="flex items-center gap-3 mb-2">
               <div className="p-2 rounded-full bg-moss-green/10">
-                <UserIcon className="w-5 h-5 text-moss-green" />
+                <UserIcon className="w-5 h-5 text-brand-ink" />
               </div>
               <div>
-                <h2 id="character-sheet-viewer-title" className="text-2xl font-bold text-moss-green">
+                <h2 id="character-sheet-viewer-title" className="text-2xl font-bold text-brand-ink">
                   {character.name}
                 </h2>
                 <div className="flex items-center gap-3 text-sm text-warm-gray">
@@ -177,8 +177,8 @@ export default function CharacterSheetViewerModal({
             {/* DM Edit Banner */}
             {isDMEditingOtherCharacter && (
               <div className="mt-3 flex items-center gap-2 px-3 py-2 bg-moss-green/10 border border-moss-green/30 rounded-lg">
-                <Shield className="w-4 h-4 text-moss-green" />
-                <p className="text-sm text-moss-green">
+                <Shield className="w-4 h-4 text-brand-ink" />
+                <p className="text-sm text-brand-ink">
                   You are viewing <strong>{ownerName}'s</strong> character as DM
                 </p>
               </div>

--- a/frontend/src/components/character/DeleteCharacterModal.tsx
+++ b/frontend/src/components/character/DeleteCharacterModal.tsx
@@ -124,7 +124,7 @@ export default function DeleteCharacterModal({
                 {!campaign && (
                   <div className="bg-moss-green/10 border border-moss-green/30 rounded-lg p-4">
                     <p className="text-sm text-stone-gray">
-                      Are you sure you want to delete <strong className="text-moss-green">{character.name}</strong>?
+                      Are you sure you want to delete <strong className="text-brand-ink">{character.name}</strong>?
                       This action cannot be undone.
                     </p>
                   </div>
@@ -132,7 +132,7 @@ export default function DeleteCharacterModal({
 
                 {/* Character Info */}
                 <div className="glass-panel p-4">
-                  <h3 className="font-semibold text-moss-green mb-2">Character Details</h3>
+                  <h3 className="font-semibold text-brand-ink mb-2">Character Details</h3>
                   <dl className="space-y-1 text-sm">
                     <div className="flex justify-between">
                       <dt className="text-warm-gray">Name:</dt>

--- a/frontend/src/components/character/ImportCharacterModal.tsx
+++ b/frontend/src/components/character/ImportCharacterModal.tsx
@@ -135,7 +135,7 @@ export default function ImportCharacterModal({
               ${isDragging ? 'border-moss-green bg-moss-green/10' : 'border-moss-green/30 hover:border-moss-green/50'}
             `}
           >
-            <Upload className="w-16 h-16 text-moss-green mx-auto mb-4" />
+            <Upload className="w-16 h-16 text-brand-ink mx-auto mb-4" />
             <h3 className="text-lg font-semibold text-ink mb-2">
               {isDragging ? 'Drop file here' : 'Upload Character JSON'}
             </h3>
@@ -185,9 +185,9 @@ export default function ImportCharacterModal({
           <div className="space-y-6">
             <div className="bg-moss-green/10 border border-moss-green/30 rounded-lg p-4">
               <div className="flex items-start gap-3 mb-4">
-                <CheckCircle className="w-5 h-5 text-moss-green flex-shrink-0 mt-0.5" />
+                <CheckCircle className="w-5 h-5 text-brand-ink flex-shrink-0 mt-0.5" />
                 <div>
-                  <h4 className="font-semibold text-moss-green mb-1">Character Loaded Successfully</h4>
+                  <h4 className="font-semibold text-brand-ink mb-1">Character Loaded Successfully</h4>
                   <p className="text-sm text-ink">Review the character details below before importing.</p>
                 </div>
               </div>
@@ -211,7 +211,7 @@ export default function ImportCharacterModal({
 
             {/* Character Preview */}
             <div className="bg-parchment rounded-lg border border-moss-green/20 p-6">
-              <h3 className="text-lg font-semibold text-moss-green mb-4 flex items-center gap-2">
+              <h3 className="text-lg font-semibold text-brand-ink mb-4 flex items-center gap-2">
                 <FileText className="w-5 h-5" />
                 Character Preview
               </h3>

--- a/frontend/src/components/character/NewCharacterModal.tsx
+++ b/frontend/src/components/character/NewCharacterModal.tsx
@@ -411,7 +411,7 @@ export default function NewCharacterModal({
                 {/* Info Box */}
                 <div className="rounded-lg p-4 bg-moss-green/10 border border-moss-green/30">
                   <p className="text-sm text-ink">
-                    <strong className="text-moss-green">Note:</strong> After
+                    <strong className="text-brand-ink">Note:</strong> After
                     creation, you'll be redirected to the character editor where
                     you can customize all details and save when ready.
                   </p>

--- a/frontend/src/components/common/ConfirmDialog.tsx
+++ b/frontend/src/components/common/ConfirmDialog.tsx
@@ -43,7 +43,7 @@ const VARIANT_CONFIG: Record<ConfirmVariant, {
     confirmClass: 'bg-warm-amber hover:bg-sunset-orange focus:ring-warm-amber text-white',
   },
   info: {
-    icon: <HelpCircle className="w-6 h-6 text-brand" aria-hidden="true" />,
+    icon: <HelpCircle className="w-6 h-6 text-brand-ink" aria-hidden="true" />,
     iconBg: 'bg-brand/10',
     confirmClass: 'bg-brand hover:bg-brand-dark focus:ring-brand text-white',
   },

--- a/frontend/src/components/common/EmptyState.tsx
+++ b/frontend/src/components/common/EmptyState.tsx
@@ -34,7 +34,7 @@ export default function EmptyState({ title, description, action, icon, className
             <img src={mascotUrl} alt="" className="w-12 h-12 object-contain animate-pulse-soft" />
           )}
         </div>
-        <h3 className="text-xl font-semibold text-moss-green mb-2">{title}</h3>
+        <h3 className="text-xl font-semibold text-brand-ink mb-2">{title}</h3>
         {description && <p className="text-warm-gray mb-6">{description}</p>}
         {action}
       </div>

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -53,14 +53,14 @@ export default class ErrorBoundary extends Component<Props, State> {
         <div className="glass-panel max-w-lg w-full p-8 text-center space-y-6">
           {/* Icon */}
           <div className="flex justify-center">
-            <div className="p-4 rounded-full bg-red-100">
-              <AlertTriangle className="w-10 h-10 text-red-600" aria-hidden="true" />
+            <div className="p-4 rounded-full bg-danger/10">
+              <AlertTriangle className="w-10 h-10 text-danger-ink" aria-hidden="true" />
             </div>
           </div>
 
           {/* Heading */}
           <div>
-            <h1 className="text-2xl font-bold text-moss-green font-heading mb-2">
+            <h1 className="text-2xl font-bold text-brand-ink font-heading mb-2">
               Something went wrong
             </h1>
             <p className="text-sm text-warm-gray">
@@ -70,11 +70,11 @@ export default class ErrorBoundary extends Component<Props, State> {
 
           {/* Error details (collapsible) */}
           {this.state.error && (
-            <details className="text-left bg-red-50 border border-red-200 rounded-lg p-4">
-              <summary className="text-sm font-medium text-red-800 cursor-pointer select-none">
+            <details className="text-left bg-danger/10 border border-danger/30 rounded-lg p-4">
+              <summary className="text-sm font-medium text-danger-ink cursor-pointer select-none">
                 Error details
               </summary>
-              <pre className="mt-2 text-xs text-red-700 overflow-x-auto whitespace-pre-wrap break-words">
+              <pre className="mt-2 text-xs text-danger-ink overflow-x-auto whitespace-pre-wrap break-words">
                 {this.state.error.message}
                 {this.state.errorInfo?.componentStack
                   ? '\n\nComponent stack:' + this.state.errorInfo.componentStack

--- a/frontend/src/components/common/GameSystemBadge.tsx
+++ b/frontend/src/components/common/GameSystemBadge.tsx
@@ -13,28 +13,32 @@ interface GameSystemBadgeProps {
 }
 
 /**
- * Color schemes for each game system
+ * Color schemes for each game system.
+ *
+ * These use the semantic tokens purely as a set of four distinguishable, themed
+ * hues — a D&D badge is not "danger", it just needs to look different from a
+ * Pathfinder one and stay readable on every theme.
  */
 const GAME_SYSTEM_COLORS: Record<GameSystem, { bg: string; text: string; border: string }> = {
   DND_5E: {
-    bg: 'bg-red-100',
-    text: 'text-red-800',
-    border: 'border-red-300',
+    bg: 'bg-danger/10',
+    text: 'text-danger-ink',
+    border: 'border-danger/30',
   },
   PATHFINDER_2E: {
-    bg: 'bg-blue-100',
-    text: 'text-blue-800',
-    border: 'border-blue-300',
+    bg: 'bg-info/10',
+    text: 'text-info-ink',
+    border: 'border-info/30',
   },
   SHADOWRUN_6E: {
-    bg: 'bg-purple-100',
-    text: 'text-purple-800',
-    border: 'border-purple-300',
+    bg: 'bg-spirit/10',
+    text: 'text-spirit-ink',
+    border: 'border-spirit/30',
   },
   CALL_OF_CTHULHU_7E: {
-    bg: 'bg-green-100',
-    text: 'text-green-800',
-    border: 'border-green-300',
+    bg: 'bg-success/10',
+    text: 'text-success-ink',
+    border: 'border-success/30',
   },
 };
 

--- a/frontend/src/components/common/LoadingOverlay.tsx
+++ b/frontend/src/components/common/LoadingOverlay.tsx
@@ -31,7 +31,7 @@ export default function LoadingOverlay({ show, message, contained = false }: Loa
         aria-label={message || 'Loading'}
         className="glass-panel px-8 py-6 flex flex-col items-center gap-4 shadow-xl"
       >
-        <Loader2 className="w-8 h-8 text-moss-green animate-spin" aria-hidden="true" />
+        <Loader2 className="w-8 h-8 text-brand-ink animate-spin" aria-hidden="true" />
         {message ? (
           <p className="text-sm font-medium text-stone-gray text-center max-w-xs">
             {message}

--- a/frontend/src/components/common/ToastContainer.tsx
+++ b/frontend/src/components/common/ToastContainer.tsx
@@ -63,23 +63,23 @@ function getToastAppearance(type: ToastItem['type']) {
   switch (type) {
     case 'success':
       return {
-        icon: <CheckCircle className="w-5 h-5 text-green-600" />,
-        styles: 'bg-green-50 border-green-200 text-green-800',
+        icon: <CheckCircle className="w-5 h-5 text-success-ink" />,
+        styles: 'bg-success/10 border-success/30 text-success-ink',
       };
     case 'error':
       return {
-        icon: <AlertCircle className="w-5 h-5 text-red-600" />,
-        styles: 'bg-red-50 border-red-200 text-red-800',
+        icon: <AlertCircle className="w-5 h-5 text-danger-ink" />,
+        styles: 'bg-danger/10 border-danger/30 text-danger-ink',
       };
     case 'warning':
       return {
-        icon: <AlertTriangle className="w-5 h-5 text-yellow-600" />,
-        styles: 'bg-yellow-50 border-yellow-200 text-yellow-800',
+        icon: <AlertTriangle className="w-5 h-5 text-warning-ink" />,
+        styles: 'bg-warning/10 border-warning/30 text-warning-ink',
       };
     default:
       return {
-        icon: <Info className="w-5 h-5 text-blue-600" />,
-        styles: 'bg-blue-50 border-blue-200 text-blue-800',
+        icon: <Info className="w-5 h-5 text-info-ink" />,
+        styles: 'bg-info/10 border-info/30 text-info-ink',
       };
   }
 }

--- a/frontend/src/components/profile/MFASection.tsx
+++ b/frontend/src/components/profile/MFASection.tsx
@@ -68,7 +68,7 @@ function DisableForm({ onClose }: { onClose: () => void }) {
 
   if (success) {
     return (
-      <div className="mt-4 flex items-center gap-2 text-sm text-moss-green">
+      <div className="mt-4 flex items-center gap-2 text-sm text-brand-ink">
         <CheckCircle className="w-4 h-4" />
         MFA disabled successfully.
       </div>
@@ -78,7 +78,7 @@ function DisableForm({ onClose }: { onClose: () => void }) {
   return (
     <form onSubmit={handleSubmit} className="mt-4 space-y-3 border-t border-moss-green/10 pt-4">
       {error && (
-        <div className="p-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">
+        <div className="p-3 rounded-lg bg-danger/10 border border-danger/30 text-sm text-danger-ink">
           {error}
         </div>
       )}
@@ -118,7 +118,7 @@ function DisableForm({ onClose }: { onClose: () => void }) {
         <button
           type="submit"
           disabled={submitting || !password || token.length !== 6}
-          className="flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-red-600 hover:bg-red-700 text-white text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-danger hover:bg-danger text-white text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {submitting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <ShieldOff className="w-3.5 h-3.5" />}
           {submitting ? 'Disabling...' : 'Disable MFA'}
@@ -177,14 +177,14 @@ function RegenerateForm({ onClose }: { onClose: () => void }) {
         <div>
           <div className="flex items-center justify-between mb-2">
             <p className="text-xs font-semibold text-stone-gray uppercase tracking-wide">New Backup Codes</p>
-            <button onClick={copyAll} className="flex items-center gap-1 text-xs text-moss-green hover:text-moss-green/80">
+            <button onClick={copyAll} className="flex items-center gap-1 text-xs text-brand-ink hover:text-brand-ink/80">
               {copied ? <CheckCircle className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
               {copied ? 'Copied!' : 'Copy all'}
             </button>
           </div>
           <div className="grid grid-cols-2 gap-1.5 p-3 rounded-lg bg-parchment/60 border border-moss-green/15">
             {newCodes.map((code, i) => (
-              <code key={i} className="text-xs font-mono text-moss-green text-center py-1 px-1.5 rounded bg-paper/60 border border-moss-green/10">
+              <code key={i} className="text-xs font-mono text-brand-ink text-center py-1 px-1.5 rounded bg-paper/60 border border-moss-green/10">
                 {code.slice(0, 4)}-{code.slice(4)}
               </code>
             ))}
@@ -198,7 +198,7 @@ function RegenerateForm({ onClose }: { onClose: () => void }) {
   return (
     <form onSubmit={handleSubmit} className="mt-4 space-y-3 border-t border-moss-green/10 pt-4">
       {error && (
-        <div className="p-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">{error}</div>
+        <div className="p-3 rounded-lg bg-danger/10 border border-danger/30 text-sm text-danger-ink">{error}</div>
       )}
       <div>
         <label className="block text-xs font-medium text-stone-gray mb-1">Current Password</label>
@@ -249,15 +249,15 @@ export default function MFASection() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           {isEnabled ? (
-            <ShieldCheck className="w-5 h-5 text-moss-green" />
+            <ShieldCheck className="w-5 h-5 text-brand-ink" />
           ) : (
             <Shield className="w-5 h-5 text-stone-gray/50" />
           )}
           <div>
-            <h3 className="text-sm font-semibold text-moss-green">Two-Factor Authentication</h3>
+            <h3 className="text-sm font-semibold text-brand-ink">Two-Factor Authentication</h3>
             <p className="text-xs text-warm-gray">
               {isEnabled ? (
-                <span className="text-moss-green font-medium">Enabled</span>
+                <span className="text-brand-ink font-medium">Enabled</span>
               ) : (
                 'Not enabled'
               )}
@@ -291,7 +291,7 @@ export default function MFASection() {
               {!isAdmin && (
                 <button
                   onClick={() => setActiveForm(activeForm === 'disable' ? null : 'disable')}
-                  className="text-sm py-1.5 px-3 rounded-lg border border-red-200 text-red-600 hover:bg-red-50 transition-colors font-medium flex items-center gap-1.5"
+                  className="text-sm py-1.5 px-3 rounded-lg border border-danger/30 text-danger-ink hover:bg-danger/10 transition-colors font-medium flex items-center gap-1.5"
                 >
                   <ShieldOff className="w-3.5 h-3.5" />
                   Disable
@@ -305,7 +305,7 @@ export default function MFASection() {
       {/* Admin MFA notice */}
       {isEnabled && isAdmin && (
         <div className="flex items-start gap-2 p-3 rounded-lg bg-moss-green/5 border border-moss-green/15">
-          <ShieldCheck className="w-4 h-4 text-moss-green flex-shrink-0 mt-0.5" />
+          <ShieldCheck className="w-4 h-4 text-brand-ink flex-shrink-0 mt-0.5" />
           <p className="text-xs text-stone-gray">
             MFA is required for admin accounts and cannot be disabled.
           </p>

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -106,10 +106,10 @@ export default function Modal({
                 <div className="flex items-center gap-3">
                   {Icon && (
                     <div className="p-2 rounded-lg bg-brand/10" aria-hidden="true">
-                      <Icon className="w-6 h-6 text-brand" />
+                      <Icon className="w-6 h-6 text-brand-ink" />
                     </div>
                   )}
-                  <h2 id={titleId} className="text-2xl font-semibold text-brand font-heading">
+                  <h2 id={titleId} className="text-2xl font-semibold text-brand-ink font-heading">
                     {title}
                   </h2>
                 </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -35,6 +35,21 @@
     /* Game-specific (not theme-dependent) */
     --color-spirit: 147 112 219;
 
+    /* ── Readable text variants and state colors ──
+       Overwritten per theme by applyThemeColors() → deriveReadableTokens();
+       these defaults match the Cozy Default palette so the app renders
+       correctly during the first paint, before a theme is applied. */
+    --color-brand-ink: 74 93 78;
+    --color-accent-ink: 138 90 43;
+    --color-spirit-ink: 106 71 178;
+    --color-danger-ink: 176 46 33;
+    --color-success: 34 139 68;
+    --color-success-ink: 30 122 60;
+    --color-warning: 191 129 20;
+    --color-warning-ink: 148 100 15;
+    --color-info: 37 99 190;
+    --color-info-ink: 37 99 190;
+
     /* ── Font Families ── */
     --font-heading: 'Quicksand', 'Comfortaa', sans-serif;
     --font-body: 'Inter', 'Open Sans', sans-serif;
@@ -103,6 +118,50 @@
   /* Card */
   .card-cozy {
     @apply glass-panel p-6 hover:shadow-xl transition-shadow duration-300;
+  }
+
+  /* ── Status messages ──
+     Use these instead of raw Tailwind colors (bg-red-50 / text-red-700 and
+     friends): those keep their light-mode look on dark themes, so an error
+     box renders as a pale pink panel. The tints below are alpha-composited
+     over whatever surface they sit on, and the text uses the derived `-ink`
+     variant, so both stay readable on every theme.
+
+       <div className="alert-danger">…</div>
+
+     For a message that is only text (no panel), use text-danger-ink /
+     text-success-ink / text-warning-ink / text-info-ink directly. */
+  .alert-danger {
+    @apply bg-danger/10 border border-danger/30 text-danger-ink rounded-cozy px-3 py-2 text-sm;
+  }
+
+  .alert-success {
+    @apply bg-success/10 border border-success/30 text-success-ink rounded-cozy px-3 py-2 text-sm;
+  }
+
+  .alert-warning {
+    @apply bg-warning/10 border border-warning/30 text-warning-ink rounded-cozy px-3 py-2 text-sm;
+  }
+
+  .alert-info {
+    @apply bg-info/10 border border-info/30 text-info-ink rounded-cozy px-3 py-2 text-sm;
+  }
+
+  /* ── Status pills ── */
+  .badge-danger {
+    @apply inline-flex items-center rounded-full bg-danger/15 text-danger-ink px-2 py-0.5 text-[10px] font-medium;
+  }
+
+  .badge-success {
+    @apply inline-flex items-center rounded-full bg-success/15 text-success-ink px-2 py-0.5 text-[10px] font-medium;
+  }
+
+  .badge-warning {
+    @apply inline-flex items-center rounded-full bg-warning/15 text-warning-ink px-2 py-0.5 text-[10px] font-medium;
+  }
+
+  .badge-neutral {
+    @apply inline-flex items-center rounded-full bg-ink-muted/15 text-ink-secondary px-2 py-0.5 text-[10px] font-medium;
   }
 }
 

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -197,6 +197,12 @@ export default function AdminPage() {
   const [createUserError, setCreateUserError] = useState('');
   const [newUserPassword, setNewUserPassword] = useState('');
   const [newUserPasswordCopied, setNewUserPasswordCopied] = useState(false);
+  // 'create' generates a temporary password; 'invite' emails a set-password link
+  const [createUserMode, setCreateUserMode] = useState<'create' | 'invite'>('create');
+  // Success message shown after an invite or an emailed create
+  const [createUserSuccess, setCreateUserSuccess] = useState('');
+  const [resendingInviteId, setResendingInviteId] = useState<string | null>(null);
+  const [resendInviteResult, setResendInviteResult] = useState<{ id: string; message: string } | null>(null);
 
   // MFA reset per-row (inline confirm)
   const [resetMfaConfirmId, setResetMfaConfirmId] = useState<string | null>(null);
@@ -418,6 +424,8 @@ export default function AdminPage() {
   useEffect(() => {
     if (activeTab === 'dashboard' && !stats && !statsLoading) loadStats();
     if (activeTab === 'users' && users.length === 0 && !usersLoading) loadUsers();
+    // The Users tab needs smtp.configured to decide whether inviting is possible
+    if (activeTab === 'users' && !serverConfig && !configLoading) loadServerConfig();
     if (activeTab === 'settings' || activeTab === 'appearance') {
       if (!settings && !settingsLoading) loadSettings();
       if (activeTab === 'settings' && !serverConfig && !configLoading) loadServerConfig();
@@ -578,18 +586,53 @@ export default function AdminPage() {
     setCreatingUser(true);
     setCreateUserError('');
     try {
-      const { user: newUser, temporaryPassword } = await adminService.createUser({
+      const payload = {
         email: createUserForm.email.trim(),
         displayName: createUserForm.displayName.trim() || undefined,
         platformRole: createUserForm.platformRole,
-      });
-      setNewUserPassword(temporaryPassword);
-      setUsers(prev => [newUser, ...prev]);
+      };
+
+      if (createUserMode === 'invite') {
+        const { user: newUser, expiresInDays } = await adminService.inviteUser(payload);
+        setCreateUserSuccess(
+          `Invitation sent to ${newUser.email}. The link expires in ${expiresInDays} days.`
+        );
+        setUsers(prev => [newUser, ...prev]);
+      } else {
+        const { user: newUser, emailSent, temporaryPassword } = await adminService.createUser(payload);
+        if (emailSent) {
+          // The user has their password by email; the admin doesn't need it
+          setCreateUserSuccess(`User created. Sign-in details were emailed to ${newUser.email}.`);
+        } else {
+          setNewUserPassword(temporaryPassword ?? '');
+        }
+        setUsers(prev => [newUser, ...prev]);
+      }
     } catch (err: unknown) {
       const e = err as { response?: { data?: { message?: string } } };
-      setCreateUserError(e.response?.data?.message ?? 'Failed to create user');
+      setCreateUserError(
+        e.response?.data?.message ??
+          (createUserMode === 'invite' ? 'Failed to send invitation' : 'Failed to create user')
+      );
     } finally {
       setCreatingUser(false);
+    }
+  };
+
+  const handleResendInvite = async (userId: string) => {
+    setResendingInviteId(userId);
+    setResendInviteResult(null);
+    try {
+      const { message } = await adminService.resendInvite(userId);
+      setResendInviteResult({ id: userId, message });
+    } catch (err: unknown) {
+      const e = err as { response?: { data?: { message?: string } } };
+      setResendInviteResult({
+        id: userId,
+        message: e.response?.data?.message ?? 'Failed to resend invitation',
+      });
+    } finally {
+      setResendingInviteId(null);
     }
   };
 
@@ -599,6 +642,7 @@ export default function AdminPage() {
     setCreateUserError('');
     setNewUserPassword('');
     setNewUserPasswordCopied(false);
+    setCreateUserSuccess('');
   };
 
   const handleResetMfa = async (userId: string) => {
@@ -993,8 +1037,20 @@ export default function AdminPage() {
             <div className="flex items-center justify-between mb-6">
               <h2 className="text-xl font-semibold text-moss-green">User Management</h2>
               <div className="flex items-center gap-2">
+                {/* Only offered when email can actually be delivered — the
+                    invitation link is the sole way into an invited account */}
+                {serverConfig?.smtp.configured && (
+                  <Button
+                    onClick={() => { setCreateUserMode('invite'); setCreateUserOpen(true); }}
+                    className="flex items-center gap-2 text-sm py-1.5 px-3"
+                  >
+                    <Mail className="w-3.5 h-3.5" />
+                    Invite User
+                  </Button>
+                )}
                 <Button
-                  onClick={() => setCreateUserOpen(true)}
+                  onClick={() => { setCreateUserMode('create'); setCreateUserOpen(true); }}
+                  variant={serverConfig?.smtp.configured ? 'secondary' : 'primary'}
                   className="flex items-center gap-2 text-sm py-1.5 px-3"
                 >
                   <UserPlus className="w-3.5 h-3.5" />
@@ -1131,10 +1187,32 @@ export default function AdminPage() {
                                 {/* Joined */}
                                 <td className="px-4 py-3 text-warm-gray text-xs">{formatDate(u.createdAt)}</td>
                                 {/* Last Login */}
-                                <td className="px-4 py-3 text-warm-gray text-xs">{formatDate(u.lastLoginAt)}</td>
+                                <td className="px-4 py-3 text-warm-gray text-xs">
+                                  {u.lastLoginAt ? (
+                                    formatDate(u.lastLoginAt)
+                                  ) : (
+                                    <span className="inline-flex items-center rounded-full bg-warm-amber/15 text-warm-amber px-2 py-0.5 text-[10px] font-medium">
+                                      Never signed in
+                                    </span>
+                                  )}
+                                </td>
                                 {/* Actions */}
                                 <td className="px-4 py-3">
                                   <div className="flex items-center justify-end gap-1.5">
+                                    {/* Resend invite — only useful before a first sign-in */}
+                                    {!u.lastLoginAt && serverConfig?.smtp.configured && (
+                                      <button
+                                        onClick={() => handleResendInvite(u.id)}
+                                        disabled={resendingInviteId === u.id}
+                                        title="Email a fresh invitation link (invalidates any previous one)"
+                                        className="text-xs py-1 px-2 flex items-center gap-1 rounded border border-moss-green/30 text-moss-green hover:bg-moss-green/5 transition-colors disabled:opacity-50"
+                                      >
+                                        {resendingInviteId === u.id
+                                          ? <Loader2 className="w-3 h-3 animate-spin" />
+                                          : <Mail className="w-3 h-3" />}
+                                        Invite
+                                      </button>
+                                    )}
                                     {/* Approve — only when pending */}
                                     {isPending && (
                                       <button
@@ -1254,6 +1332,14 @@ export default function AdminPage() {
                                 </tr>
                               )}
 
+                              {/* Resend invite result */}
+                              {resendInviteResult?.id === u.id && (
+                                <tr className="bg-moss-green/5 border-b border-warm-gray/10">
+                                  <td colSpan={7} className="px-6 py-2">
+                                    <p className="text-xs text-stone-gray">{resendInviteResult.message}</p>
+                                  </td>
+                                </tr>
+                              )}
                               {/* Reset Password Inline Panel */}
                               {isResetExpanded && (
                                 <tr className="bg-blue-50/50 border-b border-warm-gray/10">
@@ -2471,8 +2557,8 @@ export default function AdminPage() {
           <div className="bg-paper rounded-2xl shadow-2xl w-full max-w-md">
             <div className="flex items-center justify-between p-5 border-b border-warm-gray/20">
               <h2 className="text-lg font-semibold text-moss-green flex items-center gap-2">
-                <UserPlus className="w-5 h-5" />
-                Create User
+                {createUserMode === 'invite' ? <Mail className="w-5 h-5" /> : <UserPlus className="w-5 h-5" />}
+                {createUserMode === 'invite' ? 'Invite User' : 'Create User'}
               </h2>
               {!newUserPassword && (
                 <button onClick={closeCreateUserModal} className="text-warm-gray hover:text-stone-gray transition-colors">
@@ -2482,12 +2568,27 @@ export default function AdminPage() {
             </div>
 
             <div className="p-5">
-              {newUserPassword ? (
+              {createUserSuccess ? (
+                /* Invited, or created with the details emailed — no password to show */
+                <div className="space-y-4">
+                  <div className="flex items-start gap-2">
+                    <Check className="w-4 h-4 text-green-600 mt-0.5 flex-shrink-0" />
+                    <p className="text-sm text-green-700 font-medium">{createUserSuccess}</p>
+                  </div>
+                  <p className="text-xs text-warm-gray">
+                    They choose their own password, so no one else ever sees it.
+                  </p>
+                  <Button onClick={closeCreateUserModal} className="w-full">
+                    Done
+                  </Button>
+                </div>
+              ) : newUserPassword ? (
                 /* Success — show temp password */
                 <div>
                   <p className="text-sm text-green-700 font-medium mb-1">User created successfully!</p>
                   <p className="text-xs text-warm-gray mb-4">
-                    Share this temporary password securely. The user must change it on first login.
+                    Share this temporary password securely — it is shown only once, and they will be
+                    required to replace it before they can use their account.
                   </p>
                   <div className="flex items-center gap-2 mb-4">
                     <code className="flex-1 bg-warm-amber/10 border border-warm-amber/30 rounded px-3 py-2 text-sm font-mono text-stone-gray select-all">
@@ -2508,6 +2609,14 @@ export default function AdminPage() {
               ) : (
                 /* Form */
                 <div className="space-y-4">
+                  <p className="text-xs text-warm-gray">
+                    {createUserMode === 'invite'
+                      ? 'They receive an email with a link to choose their own password. No password is created, so nobody else ever sees one.'
+                      : serverConfig?.smtp.configured
+                        ? 'A temporary password is generated and emailed to them. They must replace it before they can use the account.'
+                        : 'A temporary password is generated for you to pass on. They must replace it before they can use the account.'}
+                  </p>
+
                   {createUserError && (
                     <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg p-3 text-sm">
                       {createUserError}
@@ -2571,7 +2680,7 @@ export default function AdminPage() {
                       className="flex-1 flex items-center justify-center gap-2"
                     >
                       {creatingUser && <Loader2 className="w-4 h-4 animate-spin" />}
-                      Create User
+                      {createUserMode === 'invite' ? 'Send Invitation' : 'Create User'}
                     </Button>
                     <Button
                       onClick={closeCreateUserModal}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -140,10 +140,10 @@ function formatDuration(ms: number): string {
 }
 
 const LOG_LEVEL_COLORS: Record<string, string> = {
-  INFO: 'bg-blue-100 text-blue-700',
-  WARNING: 'bg-amber-100 text-amber-700',
-  ERROR: 'bg-red-100 text-red-700',
-  CRITICAL: 'bg-red-200 text-red-900 font-bold',
+  INFO: 'bg-info/10 text-info-ink',
+  WARNING: 'bg-warning/10 text-warning-ink',
+  ERROR: 'bg-danger/10 text-danger-ink',
+  CRITICAL: 'bg-danger/20 text-danger-ink font-bold',
 };
 
 type Tab = 'dashboard' | 'users' | 'settings' | 'appearance' | 'activity' | 'backups' | 'assets';
@@ -840,13 +840,13 @@ export default function AdminPage() {
               <button
                 onClick={() => navigate('/dashboard')}
                 aria-label="Back to Dashboard"
-                className="flex items-center gap-1 text-sm text-warm-gray hover:text-moss-green transition-colors"
+                className="flex items-center gap-1 text-sm text-warm-gray hover:text-brand-ink transition-colors"
               >
                 <ChevronLeft className="w-4 h-4" aria-hidden="true" />
                 Dashboard
               </button>
               <div>
-                <h1 className="text-2xl font-bold text-moss-green font-heading flex items-center gap-2">
+                <h1 className="text-2xl font-bold text-brand-ink font-heading flex items-center gap-2">
                   <Shield className="w-6 h-6" aria-hidden="true" />
                   Admin Panel
                 </h1>
@@ -855,7 +855,7 @@ export default function AdminPage() {
             </div>
             <span className="text-sm text-warm-gray">
               Signed in as{' '}
-              <span className="font-medium text-moss-green">{user?.displayName}</span>
+              <span className="font-medium text-brand-ink">{user?.displayName}</span>
             </span>
           </div>
 
@@ -872,8 +872,8 @@ export default function AdminPage() {
                   onClick={() => setActiveTab(tab.id)}
                   className={`flex items-center gap-2 px-4 py-2 rounded-t-lg text-sm font-medium transition-colors ${
                     activeTab === tab.id
-                      ? 'bg-paper text-moss-green border border-b-paper border-moss-green/20 -mb-px'
-                      : 'text-warm-gray hover:text-moss-green hover:bg-paper/50'
+                      ? 'bg-paper text-brand-ink border border-b-paper border-moss-green/20 -mb-px'
+                      : 'text-warm-gray hover:text-brand-ink hover:bg-paper/50'
                   }`}
                 >
                   <span aria-hidden="true">{tab.icon}</span>
@@ -892,7 +892,7 @@ export default function AdminPage() {
         {activeTab === 'dashboard' && (
           <div role="tabpanel" id="tabpanel-dashboard" aria-labelledby="tab-dashboard">
             <div className="flex items-center justify-between mb-6">
-              <h2 className="text-xl font-semibold text-moss-green">System Overview</h2>
+              <h2 className="text-xl font-semibold text-brand-ink">System Overview</h2>
               <Button
                 onClick={loadStats}
                 disabled={statsLoading}
@@ -904,7 +904,7 @@ export default function AdminPage() {
             </div>
 
             {statsError && (
-              <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg p-4 mb-6 text-sm">
+              <div className="bg-danger/10 border border-danger/30 text-danger-ink rounded-lg p-4 mb-6 text-sm">
                 {statsError}
               </div>
             )}
@@ -928,58 +928,58 @@ export default function AdminPage() {
                 {/* Stat Cards */}
                 <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-4">
                   <div className="glass-panel p-5 flex flex-col items-center text-center">
-                    <Users className="w-7 h-7 text-moss-green mb-2" />
-                    <p className="text-3xl font-bold text-moss-green">{stats?.userCount ?? '\u2014'}</p>
+                    <Users className="w-7 h-7 text-brand-ink mb-2" />
+                    <p className="text-3xl font-bold text-brand-ink">{stats?.userCount ?? '\u2014'}</p>
                     <p className="text-xs text-warm-gray mt-1">Users</p>
                   </div>
 
                   <div className="glass-panel p-5 flex flex-col items-center text-center">
                     <FolderOpen className="w-7 h-7 text-warm-amber mb-2" />
-                    <p className="text-3xl font-bold text-moss-green">{stats?.campaignCount ?? '\u2014'}</p>
+                    <p className="text-3xl font-bold text-brand-ink">{stats?.campaignCount ?? '\u2014'}</p>
                     <p className="text-xs text-warm-gray mt-1">Campaigns</p>
                     {stats && (
-                      <p className="text-xs text-green-600 mt-0.5">{stats.activeCampaignCount} active</p>
+                      <p className="text-xs text-success-ink mt-0.5">{stats.activeCampaignCount} active</p>
                     )}
                   </div>
 
                   <div className="glass-panel p-5 flex flex-col items-center text-center">
-                    <CalendarDays className="w-7 h-7 text-blue-500 mb-2" />
-                    <p className="text-3xl font-bold text-moss-green">{stats?.sessionCount ?? '\u2014'}</p>
+                    <CalendarDays className="w-7 h-7 text-info-ink mb-2" />
+                    <p className="text-3xl font-bold text-brand-ink">{stats?.sessionCount ?? '\u2014'}</p>
                     <p className="text-xs text-warm-gray mt-1">Sessions</p>
                     {stats && (
-                      <p className="text-xs text-green-600 mt-0.5">{stats.activeSessionCount} live</p>
+                      <p className="text-xs text-success-ink mt-0.5">{stats.activeSessionCount} live</p>
                     )}
                   </div>
 
                   <div className="glass-panel p-5 flex flex-col items-center text-center">
-                    <BookUser className="w-7 h-7 text-indigo-500 mb-2" />
-                    <p className="text-3xl font-bold text-moss-green">{stats?.characterCount ?? '\u2014'}</p>
+                    <BookUser className="w-7 h-7 text-info-ink mb-2" />
+                    <p className="text-3xl font-bold text-brand-ink">{stats?.characterCount ?? '\u2014'}</p>
                     <p className="text-xs text-warm-gray mt-1">Characters</p>
                   </div>
 
                   <div className="glass-panel p-5 flex flex-col items-center text-center">
                     <Database className="w-7 h-7 text-teal-500 mb-2" />
-                    <p className="text-3xl font-bold text-moss-green">{stats?.mapCount ?? '\u2014'}</p>
+                    <p className="text-3xl font-bold text-brand-ink">{stats?.mapCount ?? '\u2014'}</p>
                     <p className="text-xs text-warm-gray mt-1">Maps</p>
                   </div>
 
                   <div className="glass-panel p-5 flex flex-col items-center text-center">
-                    <Database className="w-7 h-7 text-purple-500 mb-2" />
-                    <p className="text-2xl font-bold text-moss-green break-all">
+                    <Database className="w-7 h-7 text-spirit-ink mb-2" />
+                    <p className="text-2xl font-bold text-brand-ink break-all">
                       {stats ? formatBytes(stats.totalStorageBytes) : '\u2014'}
                     </p>
                     <p className="text-xs text-warm-gray mt-1">Storage</p>
                   </div>
 
                   <div className="glass-panel p-5 flex flex-col items-center text-center">
-                    <Shield className="w-7 h-7 text-green-500 mb-2" />
-                    <p className="text-sm font-bold text-green-600">Healthy</p>
+                    <Shield className="w-7 h-7 text-success-ink mb-2" />
+                    <p className="text-sm font-bold text-success-ink">Healthy</p>
                     <p className="text-xs text-warm-gray mt-1">Status</p>
                     <div className="mt-2 space-y-1 text-left w-full">
                       {[['API', true], ['DB', true], ['WS', true]].map(([label, ok]) => (
                         <div key={String(label)} className="flex items-center justify-between text-xs">
                           <span className="text-stone-gray">{label}</span>
-                          <span className={ok ? 'text-green-600' : 'text-red-500'}>&#9679;</span>
+                          <span className={ok ? 'text-success-ink' : 'text-danger-ink'}>&#9679;</span>
                         </div>
                       ))}
                     </div>
@@ -991,7 +991,7 @@ export default function AdminPage() {
                   <section className="glass-panel overflow-hidden">
                     <div className="px-4 py-3 border-b border-warm-gray/20 flex items-center gap-2">
                       <FolderOpen className="w-4 h-4 text-warm-amber" />
-                      <h3 className="font-semibold text-moss-green text-sm">Asset Breakdown</h3>
+                      <h3 className="font-semibold text-brand-ink text-sm">Asset Breakdown</h3>
                     </div>
                     <div className="overflow-x-auto">
                       <table className="w-full text-sm">
@@ -1035,7 +1035,7 @@ export default function AdminPage() {
         {activeTab === 'users' && (
           <div role="tabpanel" id="tabpanel-users" aria-labelledby="tab-users">
             <div className="flex items-center justify-between mb-6">
-              <h2 className="text-xl font-semibold text-moss-green">User Management</h2>
+              <h2 className="text-xl font-semibold text-brand-ink">User Management</h2>
               <div className="flex items-center gap-2">
                 {/* Only offered when email can actually be delivered — the
                     invitation link is the sole way into an invited account */}
@@ -1068,7 +1068,7 @@ export default function AdminPage() {
             </div>
 
             {usersError && (
-              <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg p-4 mb-4 text-sm">
+              <div className="bg-danger/10 border border-danger/30 text-danger-ink rounded-lg p-4 mb-4 text-sm">
                 {usersError}
               </div>
             )}
@@ -1127,7 +1127,7 @@ export default function AdminPage() {
                                 {/* User */}
                                 <td className="px-4 py-3">
                                   <div className="flex items-center gap-2">
-                                    <div className="w-8 h-8 rounded-full bg-moss-green/20 flex items-center justify-center text-moss-green font-medium text-xs flex-shrink-0">
+                                    <div className="w-8 h-8 rounded-full bg-moss-green/20 flex items-center justify-center text-brand-ink font-medium text-xs flex-shrink-0">
                                       {u.displayName.charAt(0).toUpperCase()}
                                     </div>
                                     <span className="font-medium text-stone-gray">{u.displayName}</span>
@@ -1135,7 +1135,7 @@ export default function AdminPage() {
                                       <span className="text-xs text-warm-gray">(you)</span>
                                     )}
                                     {isPending && (
-                                      <span className="text-xs px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 font-medium">Pending</span>
+                                      <span className="text-xs px-1.5 py-0.5 rounded-full bg-warning/10 text-warning-ink font-medium">Pending</span>
                                     )}
                                   </div>
                                 </td>
@@ -1150,7 +1150,7 @@ export default function AdminPage() {
                                       title={isSelf ? 'Cannot change your own role' : 'Click to toggle role'}
                                       className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium transition-colors ${
                                         u.platformRole === PlatformRole.ADMIN
-                                          ? 'bg-moss-green/20 text-moss-green hover:bg-moss-green/30'
+                                          ? 'bg-moss-green/20 text-brand-ink hover:bg-moss-green/30'
                                           : 'bg-warm-gray/20 text-warm-gray hover:bg-warm-gray/30'
                                       } ${isSelf ? 'opacity-60 cursor-default' : 'cursor-pointer'}`}
                                     >
@@ -1180,7 +1180,7 @@ export default function AdminPage() {
                                 </td>
                                 {/* MFA */}
                                 <td className="px-4 py-3">
-                                  <span className={`text-xs font-medium ${u.mfaEnabled ? 'text-green-600' : 'text-warm-gray'}`}>
+                                  <span className={`text-xs font-medium ${u.mfaEnabled ? 'text-success-ink' : 'text-warm-gray'}`}>
                                     {u.mfaEnabled ? 'Enabled' : 'Off'}
                                   </span>
                                 </td>
@@ -1205,7 +1205,7 @@ export default function AdminPage() {
                                         onClick={() => handleResendInvite(u.id)}
                                         disabled={resendingInviteId === u.id}
                                         title="Email a fresh invitation link (invalidates any previous one)"
-                                        className="text-xs py-1 px-2 flex items-center gap-1 rounded border border-moss-green/30 text-moss-green hover:bg-moss-green/5 transition-colors disabled:opacity-50"
+                                        className="text-xs py-1 px-2 flex items-center gap-1 rounded border border-moss-green/30 text-brand-ink hover:bg-moss-green/5 transition-colors disabled:opacity-50"
                                       >
                                         {resendingInviteId === u.id
                                           ? <Loader2 className="w-3 h-3 animate-spin" />
@@ -1219,7 +1219,7 @@ export default function AdminPage() {
                                         onClick={() => handleApproveUser(u.id)}
                                         disabled={isApproving}
                                         title="Approve this account"
-                                        className="text-xs py-1 px-2 flex items-center gap-1 rounded border border-green-300 text-green-700 hover:bg-green-50 transition-colors disabled:opacity-50"
+                                        className="text-xs py-1 px-2 flex items-center gap-1 rounded border border-success/30 text-success-ink hover:bg-success/10 transition-colors disabled:opacity-50"
                                       >
                                         {isApproving ? <Loader2 className="w-3 h-3 animate-spin" /> : <Check className="w-3 h-3" />}
                                         Approve
@@ -1244,7 +1244,7 @@ export default function AdminPage() {
                                         className={`text-xs py-1 px-2 flex items-center gap-1 rounded border transition-colors ${
                                           isSelf
                                             ? 'opacity-40 cursor-not-allowed border-warm-gray/20 text-warm-gray'
-                                            : 'border-amber-200 text-amber-700 hover:bg-amber-50'
+                                            : 'border-warning/30 text-warning-ink hover:bg-warning/10'
                                         }`}
                                       >
                                         <Shield className="w-3 h-3" />
@@ -1285,7 +1285,7 @@ export default function AdminPage() {
                                       className={`text-xs py-1 px-2 flex items-center gap-1 rounded border transition-colors ${
                                         isSelf
                                           ? 'opacity-40 cursor-not-allowed border-warm-gray/20 text-warm-gray'
-                                          : 'border-red-200 text-red-600 hover:bg-red-50'
+                                          : 'border-danger/30 text-danger-ink hover:bg-danger/10'
                                       }`}
                                     >
                                       {loadingDeleteWarning === u.id
@@ -1299,23 +1299,23 @@ export default function AdminPage() {
 
                               {/* MFA Reset Inline Confirm */}
                               {isMfaConfirm && (
-                                <tr className="bg-amber-50/60 border-b border-warm-gray/10">
+                                <tr className="bg-warning/10 border-b border-warm-gray/10">
                                   <td colSpan={7} className="px-6 py-4">
                                     <div className="max-w-md">
-                                      <p className="text-sm font-medium text-amber-800 mb-1">
+                                      <p className="text-sm font-medium text-warning-ink mb-1">
                                         Reset MFA for <strong>{u.displayName}</strong>?
                                       </p>
-                                      <p className="text-xs text-amber-700 mb-3">
+                                      <p className="text-xs text-warning-ink mb-3">
                                         This clears their authenticator app enrollment. They will need to re-enroll on next login.
                                       </p>
                                       {resetMfaError && (
-                                        <p className="text-xs text-red-600 mb-2">{resetMfaError}</p>
+                                        <p className="text-xs text-danger-ink mb-2">{resetMfaError}</p>
                                       )}
                                       <div className="flex items-center gap-2">
                                         <button
                                           onClick={() => handleResetMfa(u.id)}
                                           disabled={isResettingMfa}
-                                          className="flex items-center gap-2 px-4 py-1.5 rounded-lg text-sm font-medium bg-amber-600 text-white hover:bg-amber-700 disabled:opacity-50 transition-colors"
+                                          className="flex items-center gap-2 px-4 py-1.5 rounded-lg text-sm font-medium bg-warning text-white hover:bg-warning disabled:opacity-50 transition-colors"
                                         >
                                           {isResettingMfa && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
                                           Confirm Reset
@@ -1342,7 +1342,7 @@ export default function AdminPage() {
                               )}
                               {/* Reset Password Inline Panel */}
                               {isResetExpanded && (
-                                <tr className="bg-blue-50/50 border-b border-warm-gray/10">
+                                <tr className="bg-info/10 border-b border-warm-gray/10">
                                   <td colSpan={7} className="px-6 py-4">
                                     <div className="max-w-md">
                                       <p className="text-sm font-medium text-stone-gray mb-3">
@@ -1361,7 +1361,7 @@ export default function AdminPage() {
                                               onClick={() => handleCopyToClipboard(tempPassword, setCopied)}
                                               variant="secondary" className="flex items-center gap-1 text-xs py-2 px-3"
                                             >
-                                              {copied ? <Check className="w-3.5 h-3.5 text-green-600" /> : <Copy className="w-3.5 h-3.5" />}
+                                              {copied ? <Check className="w-3.5 h-3.5 text-success-ink" /> : <Copy className="w-3.5 h-3.5" />}
                                               {copied ? 'Copied' : 'Copy'}
                                             </Button>
                                           </div>
@@ -1378,7 +1378,7 @@ export default function AdminPage() {
                                           <div>
                                             <p className="text-xs text-warm-gray mb-1.5">Generate a temporary password to share with the user directly:</p>
                                             {resetError && (
-                                              <p className="text-xs text-red-600 mb-1.5">{resetError}</p>
+                                              <p className="text-xs text-danger-ink mb-1.5">{resetError}</p>
                                             )}
                                             <Button
                                               onClick={handleResetPassword}
@@ -1394,13 +1394,13 @@ export default function AdminPage() {
                                           <div>
                                             <p className="text-xs text-warm-gray mb-1.5">Or send a password reset link to their email address:</p>
                                             {resetLinkSent ? (
-                                              <p className="text-xs text-green-700 flex items-center gap-1">
+                                              <p className="text-xs text-success-ink flex items-center gap-1">
                                                 <Check className="w-3.5 h-3.5" /> Reset link sent to {resetTarget?.email}
                                               </p>
                                             ) : (
                                               <>
                                                 {resetLinkError && (
-                                                  <p className="text-xs text-red-600 mb-1.5">{resetLinkError}</p>
+                                                  <p className="text-xs text-danger-ink mb-1.5">{resetLinkError}</p>
                                                 )}
                                                 <Button
                                                   onClick={handleSendPasswordResetLink}
@@ -1429,18 +1429,18 @@ export default function AdminPage() {
 
                               {/* Delete Inline Panel */}
                               {isDeleteExpanded && (
-                                <tr className="bg-red-50/50 border-b border-warm-gray/10">
+                                <tr className="bg-danger/10 border-b border-warm-gray/10">
                                   <td colSpan={7} className="px-6 py-4">
                                     <div className="max-w-md">
-                                      <p className="text-sm font-medium text-red-700 mb-1">
+                                      <p className="text-sm font-medium text-danger-ink mb-1">
                                         Delete <strong>{u.displayName}</strong>?
                                       </p>
                                       <p className="text-xs text-warm-gray mb-3">
                                         This action is permanent. Type their email address to confirm.
                                       </p>
                                       {deletingUserAssetCount > 0 && (
-                                        <div className="flex items-start gap-2 mb-3 p-2.5 bg-amber-50 border border-amber-200 rounded-lg text-xs text-amber-800">
-                                          <AlertCircle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-amber-600" />
+                                        <div className="flex items-start gap-2 mb-3 p-2.5 bg-warning/10 border border-warning/30 rounded-lg text-xs text-warning-ink">
+                                          <AlertCircle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-warning-ink" />
                                           <span>
                                             This user has <strong>{deletingUserAssetCount}</strong> personal asset{deletingUserAssetCount !== 1 ? 's' : ''} that will be deleted with their account.
                                             To preserve them, promote them to Global scope from the <button onClick={() => { closeDeleteModal(); setActiveTab('assets'); }} className="underline hover:no-underline">Assets tab</button> first.
@@ -1448,7 +1448,7 @@ export default function AdminPage() {
                                         </div>
                                       )}
                                       {deleteError && (
-                                        <p className="text-xs text-red-600 mb-2">{deleteError}</p>
+                                        <p className="text-xs text-danger-ink mb-2">{deleteError}</p>
                                       )}
                                       <div className="flex items-center gap-2">
                                         <input
@@ -1461,7 +1461,7 @@ export default function AdminPage() {
                                         <button
                                           onClick={handleDeleteUser}
                                           disabled={deleteEmail !== u.email || isDeleting}
-                                          className="flex items-center gap-1 px-4 py-2 rounded-lg text-sm font-medium bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                                          className="flex items-center gap-1 px-4 py-2 rounded-lg text-sm font-medium bg-danger text-white hover:bg-danger disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                                         >
                                           {isDeleting && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
                                           Delete
@@ -1498,7 +1498,7 @@ export default function AdminPage() {
         {activeTab === 'assets' && (
           <div role="tabpanel" id="tabpanel-assets" aria-labelledby="tab-assets">
             <div className="flex items-center justify-between mb-6">
-              <h2 className="text-xl font-semibold text-moss-green">Asset Management</h2>
+              <h2 className="text-xl font-semibold text-brand-ink">Asset Management</h2>
               <Button
                 onClick={() => loadAdminAssets(adminAssetsPage, adminAssetsScope, adminAssetsType, debouncedAdminAssetsSearch)}
                 disabled={adminAssetsLoading}
@@ -1558,7 +1558,7 @@ export default function AdminPage() {
             </div>
 
             {adminAssetsError && (
-              <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg p-4 mb-4 text-sm">
+              <div className="bg-danger/10 border border-danger/30 text-danger-ink rounded-lg p-4 mb-4 text-sm">
                 {adminAssetsError}
               </div>
             )}
@@ -1629,7 +1629,7 @@ export default function AdminPage() {
                               <td className="px-3 py-2">
                                 <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded-full bg-parchment border border-moss-green/20 text-stone-gray">
                                   {asset.type === AssetType.MAP && <MapPin className="w-3 h-3 text-warm-amber" />}
-                                  {asset.type === AssetType.TOKEN && <UserIcon className="w-3 h-3 text-moss-green" />}
+                                  {asset.type === AssetType.TOKEN && <UserIcon className="w-3 h-3 text-brand-ink" />}
                                   {asset.type === AssetType.AUDIO && <FileAudio className="w-3 h-3 text-spirit-purple" />}
                                   {asset.type === AssetType.AVATAR && <UserIcon className="w-3 h-3 text-sunset-orange" />}
                                   {asset.type}
@@ -1639,9 +1639,9 @@ export default function AdminPage() {
                               <td className="px-3 py-2">
                                 <span className={`inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded-full font-medium ${
                                   asset.scope === AssetScope.GLOBAL
-                                    ? 'bg-purple-100 text-purple-700'
+                                    ? 'bg-spirit/10 text-spirit-ink'
                                     : asset.scope === AssetScope.USER
-                                      ? 'bg-moss-green/15 text-moss-green'
+                                      ? 'bg-moss-green/15 text-brand-ink'
                                       : 'bg-warm-amber/15 text-warm-amber'
                                 }`}>
                                   {asset.scope === AssetScope.GLOBAL && <Globe className="w-3 h-3" />}
@@ -1686,7 +1686,7 @@ export default function AdminPage() {
                                       <option value={AssetScope.CAMPAIGN}>Campaign…</option>
                                     </select>
                                     {isChangingScope && (
-                                      <Loader2 className="absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 animate-spin text-moss-green pointer-events-none" />
+                                      <Loader2 className="absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 animate-spin text-brand-ink pointer-events-none" />
                                     )}
                                     {!isChangingScope && (
                                       <ArrowRightLeft className="absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 text-warm-gray/60 pointer-events-none" />
@@ -1696,7 +1696,7 @@ export default function AdminPage() {
                                   <button
                                     onClick={() => handleAdminDeleteAsset(asset.id)}
                                     disabled={isDeleting || isChangingScope}
-                                    className="text-xs py-1 px-2 flex items-center gap-1 rounded border border-red-200 text-red-600 hover:bg-red-50 transition-colors disabled:opacity-50"
+                                    className="text-xs py-1 px-2 flex items-center gap-1 rounded border border-danger/30 text-danger-ink hover:bg-danger/10 transition-colors disabled:opacity-50"
                                     title="Delete asset"
                                   >
                                     {isDeleting
@@ -1791,11 +1791,11 @@ export default function AdminPage() {
         {/* ===== SETTINGS TAB ===== */}
         {activeTab === 'settings' && (
           <div role="tabpanel" id="tabpanel-settings" aria-labelledby="tab-settings" className="max-w-2xl space-y-6">
-            <h2 className="text-xl font-semibold text-moss-green">System Settings</h2>
+            <h2 className="text-xl font-semibold text-brand-ink">System Settings</h2>
 
             {settingsLoading && !settings ? (
               <div className="flex items-center justify-center py-20">
-                <Loader2 className="w-8 h-8 text-moss-green animate-spin" />
+                <Loader2 className="w-8 h-8 text-brand-ink animate-spin" />
               </div>
             ) : (
               <section className="glass-panel p-6 space-y-6">
@@ -1885,7 +1885,7 @@ export default function AdminPage() {
 
                 <div className="pt-2 border-t border-warm-gray/20 flex items-center gap-3">
                   {settingsError && (
-                    <p className="text-sm text-red-600 flex-1">{settingsError}</p>
+                    <p className="text-sm text-danger-ink flex-1">{settingsError}</p>
                   )}
                   <Button
                     onClick={handleSaveSettings}
@@ -1904,7 +1904,7 @@ export default function AdminPage() {
             <section className="glass-panel p-6 space-y-4">
               <div className="flex items-center gap-2 pb-2 border-b border-warm-gray/20">
                 <Mail className="w-4 h-4 text-warm-amber" />
-                <h3 className="font-semibold text-moss-green text-sm">SMTP Configuration</h3>
+                <h3 className="font-semibold text-brand-ink text-sm">SMTP Configuration</h3>
                 <span className="ml-auto text-xs text-warm-gray">Read-only — set via environment variables</span>
               </div>
 
@@ -1918,10 +1918,10 @@ export default function AdminPage() {
                   <div className="flex items-center gap-3">
                     <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ${
                       serverConfig.smtp.configured
-                        ? 'bg-green-100 text-green-700'
-                        : 'bg-amber-100 text-amber-700'
+                        ? 'bg-success/10 text-success-ink'
+                        : 'bg-warning/10 text-warning-ink'
                     }`}>
-                      <span className={`w-1.5 h-1.5 rounded-full ${serverConfig.smtp.configured ? 'bg-green-500' : 'bg-amber-500'}`} />
+                      <span className={`w-1.5 h-1.5 rounded-full ${serverConfig.smtp.configured ? 'bg-success' : 'bg-warning'}`} />
                       {serverConfig.smtp.configured ? 'Configured' : 'Not configured'}
                     </span>
                     {serverConfig.smtp.configured && (
@@ -1938,7 +1938,7 @@ export default function AdminPage() {
                       <button
                         onClick={handleSmtpTest}
                         disabled={smtpTesting}
-                        className="flex items-center gap-2 text-sm py-1.5 px-3 rounded-lg border border-moss-green/30 text-moss-green hover:bg-moss-green/10 transition-colors disabled:opacity-50"
+                        className="flex items-center gap-2 text-sm py-1.5 px-3 rounded-lg border border-moss-green/30 text-brand-ink hover:bg-moss-green/10 transition-colors disabled:opacity-50"
                       >
                         {smtpTesting
                           ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
@@ -1947,7 +1947,7 @@ export default function AdminPage() {
                         Send Test Email
                       </button>
                       {smtpTestResult && (
-                        <span className={`text-xs ${smtpTestResult.ok ? 'text-green-600' : 'text-red-600'}`}>
+                        <span className={`text-xs ${smtpTestResult.ok ? 'text-success-ink' : 'text-danger-ink'}`}>
                           {smtpTestResult.ok ? '✓' : '✗'} {smtpTestResult.message}
                         </span>
                       )}
@@ -1972,7 +1972,7 @@ export default function AdminPage() {
             <section className="glass-panel p-6 space-y-4">
               <div className="flex items-center gap-2 pb-2 border-b border-warm-gray/20">
                 <FolderOpen className="w-4 h-4 text-warm-amber" />
-                <h3 className="font-semibold text-moss-green text-sm">Upload Size Limits</h3>
+                <h3 className="font-semibold text-brand-ink text-sm">Upload Size Limits</h3>
                 <span className="ml-auto text-xs text-warm-gray">Read-only — set via environment variables</span>
               </div>
 
@@ -2017,7 +2017,7 @@ export default function AdminPage() {
             <section className="glass-panel p-6 space-y-4">
               <div className="flex items-center gap-2 pb-2 border-b border-warm-gray/20">
                 <Clock className="w-4 h-4 text-warm-amber" />
-                <h3 className="font-semibold text-moss-green text-sm">Session Timeouts</h3>
+                <h3 className="font-semibold text-brand-ink text-sm">Session Timeouts</h3>
                 <span className="ml-auto text-xs text-warm-gray">Read-only — set via environment variables</span>
               </div>
 
@@ -2060,7 +2060,7 @@ export default function AdminPage() {
         {activeTab === 'appearance' && (
           <div role="tabpanel" id="tabpanel-appearance" aria-labelledby="tab-appearance" className="max-w-3xl space-y-6">
             <div>
-              <h2 className="text-xl font-semibold text-moss-green">Default Theme &amp; Branding</h2>
+              <h2 className="text-xl font-semibold text-brand-ink">Default Theme &amp; Branding</h2>
               <p className="text-sm text-warm-gray mt-1">
                 The default theme is shown on the login page and applied to brand-new users.
                 Each user can pick their own theme from their <span className="font-medium">Profile</span>.
@@ -2070,7 +2070,7 @@ export default function AdminPage() {
 
             {settingsLoading && !settings ? (
               <div className="flex items-center justify-center py-20">
-                <Loader2 className="w-8 h-8 text-moss-green animate-spin" />
+                <Loader2 className="w-8 h-8 text-brand-ink animate-spin" />
               </div>
             ) : (
               <>
@@ -2090,7 +2090,7 @@ export default function AdminPage() {
                 {/* Save Appearance */}
                 <div className="flex items-center gap-3">
                   {appearanceError && (
-                    <p className="text-sm text-red-600 flex-1">{appearanceError}</p>
+                    <p className="text-sm text-danger-ink flex-1">{appearanceError}</p>
                   )}
                   <Button
                     onClick={async () => {
@@ -2140,7 +2140,7 @@ export default function AdminPage() {
         {activeTab === 'backups' && (
           <div role="tabpanel" id="tabpanel-backups" aria-labelledby="tab-backups" className="max-w-3xl space-y-6">
             <div className="flex items-center justify-between">
-              <h2 className="text-xl font-semibold text-moss-green">Instance Backups</h2>
+              <h2 className="text-xl font-semibold text-brand-ink">Instance Backups</h2>
               <div className="flex items-center gap-2">
                 <Button
                   onClick={handleCreateBackup}
@@ -2165,22 +2165,22 @@ export default function AdminPage() {
             </div>
 
             {backupCreateError && (
-              <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg p-4 text-sm flex items-start gap-2">
+              <div className="bg-danger/10 border border-danger/30 text-danger-ink rounded-lg p-4 text-sm flex items-start gap-2">
                 <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
                 <span>{backupCreateError}</span>
               </div>
             )}
 
             {backupsError && (
-              <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg p-4 text-sm">
+              <div className="bg-danger/10 border border-danger/30 text-danger-ink rounded-lg p-4 text-sm">
                 {backupsError}
               </div>
             )}
 
             <section className="glass-panel overflow-hidden">
               <div className="px-4 py-3 border-b border-warm-gray/20 flex items-center gap-2">
-                <Database className="w-4 h-4 text-moss-green" />
-                <h3 className="font-semibold text-moss-green text-sm">Available Backups</h3>
+                <Database className="w-4 h-4 text-brand-ink" />
+                <h3 className="font-semibold text-brand-ink text-sm">Available Backups</h3>
                 {backups.length > 0 && (
                   <span className="ml-auto text-xs text-warm-gray">{backups.length} backup{backups.length !== 1 ? 's' : ''}</span>
                 )}
@@ -2188,7 +2188,7 @@ export default function AdminPage() {
 
               {backupsLoading && backups.length === 0 ? (
                 <div className="flex items-center justify-center py-12">
-                  <Loader2 className="w-6 h-6 text-moss-green animate-spin" />
+                  <Loader2 className="w-6 h-6 text-brand-ink animate-spin" />
                 </div>
               ) : backups.length === 0 ? (
                 <div className="text-center py-10 text-warm-gray">
@@ -2218,7 +2218,7 @@ export default function AdminPage() {
                               <a
                                 href={adminService.getBackupDownloadUrl(b.filename)}
                                 download={b.filename}
-                                className="text-xs py-1 px-2 flex items-center gap-1 rounded border border-moss-green/30 text-moss-green hover:bg-moss-green/10 transition-colors"
+                                className="text-xs py-1 px-2 flex items-center gap-1 rounded border border-moss-green/30 text-brand-ink hover:bg-moss-green/10 transition-colors"
                               >
                                 <Download className="w-3 h-3" />
                                 Download
@@ -2226,7 +2226,7 @@ export default function AdminPage() {
                               <button
                                 onClick={() => handleDeleteBackup(b.filename)}
                                 disabled={deletingBackupFile === b.filename}
-                                className="text-xs py-1 px-2 flex items-center gap-1 rounded border border-red-200 text-red-600 hover:bg-red-50 transition-colors disabled:opacity-50"
+                                className="text-xs py-1 px-2 flex items-center gap-1 rounded border border-danger/30 text-danger-ink hover:bg-danger/10 transition-colors disabled:opacity-50"
                               >
                                 {deletingBackupFile === b.filename
                                   ? <Loader2 className="w-3 h-3 animate-spin" />
@@ -2243,15 +2243,15 @@ export default function AdminPage() {
               )}
             </section>
 
-            <section className="glass-panel overflow-hidden border border-red-200/40">
-              <div className="px-4 py-3 border-b border-red-200/30 flex items-center gap-2 bg-red-50/30">
-                <RotateCcw className="w-4 h-4 text-red-600" />
-                <h3 className="font-semibold text-red-700 text-sm">Restore from Backup</h3>
+            <section className="glass-panel overflow-hidden border border-danger/40">
+              <div className="px-4 py-3 border-b border-danger/30 flex items-center gap-2 bg-danger/10">
+                <RotateCcw className="w-4 h-4 text-danger-ink" />
+                <h3 className="font-semibold text-danger-ink text-sm">Restore from Backup</h3>
               </div>
               <div className="p-5 space-y-4">
                 {restoreSuccess ? (
                   <div className="bg-moss-green/10 border border-moss-green/30 rounded-lg p-4 text-center space-y-2">
-                    <p className="text-sm font-semibold text-moss-green">Restore complete!</p>
+                    <p className="text-sm font-semibold text-brand-ink">Restore complete!</p>
                     <p className="text-xs text-warm-gray">
                       The database and files have been restored. Your current session is no longer valid.
                     </p>
@@ -2264,9 +2264,9 @@ export default function AdminPage() {
                   </div>
                 ) : (
                   <>
-                    <div className="bg-red-50 border border-red-200/60 rounded-lg p-3 flex items-start gap-2">
-                      <AlertCircle className="w-4 h-4 text-red-600 mt-0.5 flex-shrink-0" />
-                      <p className="text-xs text-red-700">
+                    <div className="bg-danger/10 border border-danger/60 rounded-lg p-3 flex items-start gap-2">
+                      <AlertCircle className="w-4 h-4 text-danger-ink mt-0.5 flex-shrink-0" />
+                      <p className="text-xs text-danger-ink">
                         Restoring will <strong>permanently overwrite</strong> the current database and all uploaded files.
                         This cannot be undone. Make sure you have a recent backup before proceeding.
                       </p>
@@ -2298,7 +2298,7 @@ export default function AdminPage() {
                     </div>
 
                     {restoreError && (
-                      <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg p-3 text-xs flex items-start gap-2">
+                      <div className="bg-danger/10 border border-danger/30 text-danger-ink rounded-lg p-3 text-xs flex items-start gap-2">
                         <AlertCircle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
                         {restoreError}
                       </div>
@@ -2308,7 +2308,7 @@ export default function AdminPage() {
                       <button
                         onClick={handleRestoreBackup}
                         disabled={restoring}
-                        className="flex items-center gap-2 text-sm py-1.5 px-4 rounded-lg bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 transition-colors font-medium"
+                        className="flex items-center gap-2 text-sm py-1.5 px-4 rounded-lg bg-danger text-white hover:bg-danger disabled:opacity-50 transition-colors font-medium"
                       >
                         {restoring
                           ? <><Loader2 className="w-3.5 h-3.5 animate-spin" /> Restoring…</>
@@ -2327,7 +2327,7 @@ export default function AdminPage() {
         {activeTab === 'activity' && (
           <div role="tabpanel" id="tabpanel-activity" aria-labelledby="tab-activity">
             <div className="flex items-center justify-between mb-6">
-              <h2 className="text-xl font-semibold text-moss-green">Platform Activity</h2>
+              <h2 className="text-xl font-semibold text-brand-ink">Platform Activity</h2>
               <Button
                 onClick={loadActivity}
                 disabled={activityLoading}
@@ -2339,7 +2339,7 @@ export default function AdminPage() {
             </div>
 
             {activityError && (
-              <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg p-4 mb-6 text-sm">
+              <div className="bg-danger/10 border border-danger/30 text-danger-ink rounded-lg p-4 mb-6 text-sm">
                 {activityError}
               </div>
             )}
@@ -2358,10 +2358,10 @@ export default function AdminPage() {
                 {/* Currently Online */}
                 <section className="glass-panel overflow-hidden">
                   <div className="px-4 py-3 border-b border-warm-gray/20 flex items-center gap-2">
-                    <Wifi className="w-4 h-4 text-green-500" />
-                    <h3 className="font-semibold text-moss-green text-sm">Currently Online</h3>
+                    <Wifi className="w-4 h-4 text-success-ink" />
+                    <h3 className="font-semibold text-brand-ink text-sm">Currently Online</h3>
                     {activity?.onlineUsers && (
-                      <span className="ml-auto text-xs font-medium text-green-600">
+                      <span className="ml-auto text-xs font-medium text-success-ink">
                         {activity.onlineUsers.length} active {activity.onlineUsers.length === 1 ? 'session' : 'sessions'}
                       </span>
                     )}
@@ -2385,7 +2385,7 @@ export default function AdminPage() {
                             <tr key={u.id} className="border-b border-warm-gray/10 hover:bg-moss-green/5">
                               <td className="px-4 py-2">
                                 <div className="flex items-center gap-2">
-                                  <span className="inline-block w-2 h-2 rounded-full bg-green-500 flex-shrink-0" />
+                                  <span className="inline-block w-2 h-2 rounded-full bg-success flex-shrink-0" />
                                   <span className="font-medium text-stone-gray">{u.displayName}</span>
                                 </div>
                               </td>
@@ -2393,7 +2393,7 @@ export default function AdminPage() {
                               <td className="px-4 py-2">
                                 <span className={`text-xs px-1.5 py-0.5 rounded-full ${
                                   u.platformRole === PlatformRole.ADMIN
-                                    ? 'bg-moss-green/20 text-moss-green'
+                                    ? 'bg-moss-green/20 text-brand-ink'
                                     : 'bg-warm-gray/20 text-warm-gray'
                                 }`}>
                                   {u.platformRole}
@@ -2413,7 +2413,7 @@ export default function AdminPage() {
                 <section className="glass-panel overflow-hidden">
                   <div className="px-4 py-3 border-b border-warm-gray/20 flex items-center gap-2">
                     <Clock className="w-4 h-4 text-warm-amber" />
-                    <h3 className="font-semibold text-moss-green text-sm">Recent Admin Actions</h3>
+                    <h3 className="font-semibold text-brand-ink text-sm">Recent Admin Actions</h3>
                     <span className="text-xs text-warm-gray ml-auto">last 100</span>
                   </div>
                   {!activity?.recentLogs?.length ? (
@@ -2449,8 +2449,8 @@ export default function AdminPage() {
                 {/* Recent Registrations */}
                 <section className="glass-panel overflow-hidden">
                   <div className="px-4 py-3 border-b border-warm-gray/20 flex items-center gap-2">
-                    <Users className="w-4 h-4 text-moss-green" />
-                    <h3 className="font-semibold text-moss-green text-sm">Recent Registrations</h3>
+                    <Users className="w-4 h-4 text-brand-ink" />
+                    <h3 className="font-semibold text-brand-ink text-sm">Recent Registrations</h3>
                     <span className="text-xs text-warm-gray ml-auto">50 most recent</span>
                   </div>
                   <div className="overflow-x-auto">
@@ -2478,14 +2478,14 @@ export default function AdminPage() {
                               <td className="px-4 py-2">
                                 <span className={`text-xs px-1.5 py-0.5 rounded-full ${
                                   u.platformRole === PlatformRole.ADMIN
-                                    ? 'bg-moss-green/20 text-moss-green'
+                                    ? 'bg-moss-green/20 text-brand-ink'
                                     : 'bg-warm-gray/20 text-warm-gray'
                                 }`}>
                                   {u.platformRole}
                                 </span>
                               </td>
                               <td className="px-4 py-2">
-                                <span className={`text-xs ${u.mfaEnabled ? 'text-green-600' : 'text-warm-gray'}`}>
+                                <span className={`text-xs ${u.mfaEnabled ? 'text-success-ink' : 'text-warm-gray'}`}>
                                   {u.mfaEnabled ? 'On' : 'Off'}
                                 </span>
                               </td>
@@ -2502,8 +2502,8 @@ export default function AdminPage() {
                 {/* Recent Game Sessions */}
                 <section className="glass-panel overflow-hidden">
                   <div className="px-4 py-3 border-b border-warm-gray/20 flex items-center gap-2">
-                    <CalendarDays className="w-4 h-4 text-blue-500" />
-                    <h3 className="font-semibold text-moss-green text-sm">Recent Game Sessions</h3>
+                    <CalendarDays className="w-4 h-4 text-info-ink" />
+                    <h3 className="font-semibold text-brand-ink text-sm">Recent Game Sessions</h3>
                     <span className="text-xs text-warm-gray ml-auto">20 most recent</span>
                   </div>
                   <div className="overflow-x-auto">
@@ -2530,7 +2530,7 @@ export default function AdminPage() {
                               <td className="px-4 py-2 text-xs">
                                 {s.endedAt
                                   ? <span className="text-warm-gray">{formatDate(s.endedAt)}</span>
-                                  : <span className="text-green-600 font-medium">In progress</span>
+                                  : <span className="text-success-ink font-medium">In progress</span>
                                 }
                               </td>
                             </tr>
@@ -2556,7 +2556,7 @@ export default function AdminPage() {
         >
           <div className="bg-paper rounded-2xl shadow-2xl w-full max-w-md">
             <div className="flex items-center justify-between p-5 border-b border-warm-gray/20">
-              <h2 className="text-lg font-semibold text-moss-green flex items-center gap-2">
+              <h2 className="text-lg font-semibold text-brand-ink flex items-center gap-2">
                 {createUserMode === 'invite' ? <Mail className="w-5 h-5" /> : <UserPlus className="w-5 h-5" />}
                 {createUserMode === 'invite' ? 'Invite User' : 'Create User'}
               </h2>
@@ -2572,8 +2572,8 @@ export default function AdminPage() {
                 /* Invited, or created with the details emailed — no password to show */
                 <div className="space-y-4">
                   <div className="flex items-start gap-2">
-                    <Check className="w-4 h-4 text-green-600 mt-0.5 flex-shrink-0" />
-                    <p className="text-sm text-green-700 font-medium">{createUserSuccess}</p>
+                    <Check className="w-4 h-4 text-success-ink mt-0.5 flex-shrink-0" />
+                    <p className="text-sm text-success-ink font-medium">{createUserSuccess}</p>
                   </div>
                   <p className="text-xs text-warm-gray">
                     They choose their own password, so no one else ever sees it.
@@ -2585,7 +2585,7 @@ export default function AdminPage() {
               ) : newUserPassword ? (
                 /* Success — show temp password */
                 <div>
-                  <p className="text-sm text-green-700 font-medium mb-1">User created successfully!</p>
+                  <p className="text-sm text-success-ink font-medium mb-1">User created successfully!</p>
                   <p className="text-xs text-warm-gray mb-4">
                     Share this temporary password securely — it is shown only once, and they will be
                     required to replace it before they can use their account.
@@ -2598,7 +2598,7 @@ export default function AdminPage() {
                       onClick={() => handleCopyToClipboard(newUserPassword, setNewUserPasswordCopied)}
                       variant="secondary" className="flex items-center gap-1 text-xs py-2 px-3"
                     >
-                      {newUserPasswordCopied ? <Check className="w-3.5 h-3.5 text-green-600" /> : <Copy className="w-3.5 h-3.5" />}
+                      {newUserPasswordCopied ? <Check className="w-3.5 h-3.5 text-success-ink" /> : <Copy className="w-3.5 h-3.5" />}
                       {newUserPasswordCopied ? 'Copied' : 'Copy'}
                     </Button>
                   </div>
@@ -2618,14 +2618,14 @@ export default function AdminPage() {
                   </p>
 
                   {createUserError && (
-                    <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg p-3 text-sm">
+                    <div className="bg-danger/10 border border-danger/30 text-danger-ink rounded-lg p-3 text-sm">
                       {createUserError}
                     </div>
                   )}
 
                   <div>
                     <label className="block text-sm font-medium text-stone-gray mb-1">
-                      Email <span className="text-red-500">*</span>
+                      Email <span className="text-danger-ink">*</span>
                     </label>
                     <input
                       type="email"

--- a/frontend/src/pages/AssetLibraryPage.tsx
+++ b/frontend/src/pages/AssetLibraryPage.tsx
@@ -180,7 +180,7 @@ export default function AssetLibraryPage() {
                 <span className="hidden sm:inline">Dashboard</span>
               </Button>
               <div>
-                <h1 className="text-3xl font-bold text-moss-green mb-2">Asset Library</h1>
+                <h1 className="text-3xl font-bold text-brand-ink mb-2">Asset Library</h1>
                 <p className="text-stone-gray">Manage your maps, tokens, audio, and avatars</p>
               </div>
             </div>
@@ -353,9 +353,9 @@ export default function AssetLibraryPage() {
             ))}
           </div>
         ) : toast?.type === 'error' && filteredAssets.length === 0 ? (
-          <div className="bg-parchment/50 border border-red-500/20 rounded-xl p-12 text-center">
-            <AlertCircle className="w-12 h-12 mx-auto mb-4 text-red-400" />
-            <h2 className="text-lg font-semibold text-moss-green mb-2">Failed to load assets</h2>
+          <div className="bg-parchment/50 border border-danger/20 rounded-xl p-12 text-center">
+            <AlertCircle className="w-12 h-12 mx-auto mb-4 text-danger-ink" />
+            <h2 className="text-lg font-semibold text-brand-ink mb-2">Failed to load assets</h2>
             <p className="text-stone-gray mb-6 text-sm">Check your connection and try again.</p>
             <Button onClick={() => assetsQuery.refetch()}>
               Try Again
@@ -364,7 +364,7 @@ export default function AssetLibraryPage() {
         ) : filteredAssets.length === 0 ? (
           <div className="bg-parchment/50 border border-moss-green/20 rounded-xl p-12 text-center">
             <FolderOpen className="w-16 h-16 mx-auto mb-4 text-stone-gray/30" />
-            <h2 className="text-xl font-semibold text-moss-green mb-2">No assets found</h2>
+            <h2 className="text-xl font-semibold text-brand-ink mb-2">No assets found</h2>
             <p className="text-stone-gray mb-6">
               {searchQuery || selectedTags.length > 0
                 ? 'Try adjusting your search or filters'

--- a/frontend/src/pages/CampaignPage.tsx
+++ b/frontend/src/pages/CampaignPage.tsx
@@ -175,7 +175,7 @@ function CampaignPageContent() {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-soft-cream via-parchment to-warm-amber/20">
         <div className="text-center space-y-4">
-          <Loader2 className="w-12 h-12 text-moss-green animate-spin mx-auto" />
+          <Loader2 className="w-12 h-12 text-brand-ink animate-spin mx-auto" />
           <p className="text-stone-gray">Loading campaign...</p>
         </div>
       </div>
@@ -227,7 +227,7 @@ function CampaignPageContent() {
 
           <div className="h-6 w-px bg-moss-green/20" />
 
-          <h1 className="text-xl font-bold text-moss-green">
+          <h1 className="text-xl font-bold text-brand-ink">
             {campaign.name}
           </h1>
         </div>
@@ -238,9 +238,9 @@ function CampaignPageContent() {
 
           {/* Session status indicator (visible to all) */}
           {campaign.status === CampaignStatus.ACTIVE && (
-            <div className="flex items-center gap-1.5 px-2 py-1 rounded-lg bg-green-500/10 border border-green-500/20">
-              <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
-              <span className="text-xs font-medium text-green-700 hidden sm:inline">Live</span>
+            <div className="flex items-center gap-1.5 px-2 py-1 rounded-lg bg-success/10 border border-success/20">
+              <div className="w-2 h-2 rounded-full bg-success animate-pulse" />
+              <span className="text-xs font-medium text-success-ink hidden sm:inline">Live</span>
             </div>
           )}
           {campaign.status === CampaignStatus.PAUSED && (
@@ -364,7 +364,7 @@ function CampaignPageContent() {
               <Suspense
                 fallback={
                   <div className="w-full h-full flex items-center justify-center" aria-live="polite" aria-label="Loading map">
-                    <Loader2 className="w-8 h-8 text-moss-green animate-spin" aria-hidden="true" />
+                    <Loader2 className="w-8 h-8 text-brand-ink animate-spin" aria-hidden="true" />
                   </div>
                 }
               >
@@ -473,7 +473,7 @@ function CampaignPageContent() {
       {/* Mobile Warning */}
       <div className="lg:hidden fixed inset-0 bg-black/80 flex items-center justify-center p-4 z-50">
         <div className="card-cozy max-w-md text-center space-y-4">
-          <h2 className="text-xl font-bold text-moss-green">
+          <h2 className="text-xl font-bold text-brand-ink">
             Desktop Required
           </h2>
           <p className="text-stone-gray">

--- a/frontend/src/pages/CharacterEditorPage.tsx
+++ b/frontend/src/pages/CharacterEditorPage.tsx
@@ -254,7 +254,7 @@ export default function CharacterEditorPage() {
       <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-soft-cream via-parchment to-warm-amber/20 p-4">
         <div className="glass-panel p-8 max-w-md w-full text-center">
           <AlertCircle className="w-12 h-12 text-spirit-red mx-auto mb-4" />
-          <h2 className="text-2xl font-bold text-moss-green mb-2">
+          <h2 className="text-2xl font-bold text-brand-ink mb-2">
             Failed to Load Character
           </h2>
           <p className="text-stone-gray mb-6">{error || 'Character not found'}</p>
@@ -272,7 +272,7 @@ export default function CharacterEditorPage() {
       <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-soft-cream via-parchment to-warm-amber/20 p-4">
         <div className="glass-panel p-8 max-w-md w-full text-center">
           <Lock className="w-12 h-12 text-sunset-orange mx-auto mb-4" />
-          <h2 className="text-2xl font-bold text-moss-green mb-2">
+          <h2 className="text-2xl font-bold text-brand-ink mb-2">
             Permission Denied
           </h2>
           <p className="text-stone-gray mb-6">{permissionError}</p>
@@ -307,10 +307,10 @@ export default function CharacterEditorPage() {
               className="p-2 rounded-lg hover:bg-moss-green/10 transition-colors"
               aria-label="Back to characters"
             >
-              <ArrowLeft className="w-5 h-5 text-moss-green" />
+              <ArrowLeft className="w-5 h-5 text-brand-ink" />
             </button>
             <div>
-              <h1 className="text-2xl font-bold text-moss-green">
+              <h1 className="text-2xl font-bold text-brand-ink">
                 Editing: {character.name}
               </h1>
               {campaign && (
@@ -327,7 +327,7 @@ export default function CharacterEditorPage() {
               <span className="text-sm text-sunset-orange">Unsaved changes</span>
             )}
             {saving && (
-              <span className="text-sm text-moss-green flex items-center gap-2">
+              <span className="text-sm text-brand-ink flex items-center gap-2">
                 <Loader2 className="w-4 h-4 animate-spin" />
                 Saving...
               </span>

--- a/frontend/src/pages/CharactersPage.tsx
+++ b/frontend/src/pages/CharactersPage.tsx
@@ -164,7 +164,7 @@ export default function CharactersPage() {
                 <img src={mascotUrl} alt="CozyVTT" className="w-10 h-10 object-contain" />
               </button>
               <div>
-                <h1 className="text-3xl font-bold text-moss-green font-heading">
+                <h1 className="text-3xl font-bold text-brand-ink font-heading">
                   My Characters
                 </h1>
                 <p className="text-sm text-warm-gray">
@@ -215,7 +215,7 @@ export default function CharactersPage() {
           {/* Create Character Section */}
           <section>
             <div className="flex items-center justify-between mb-6">
-              <h2 className="text-2xl font-semibold text-moss-green font-heading">
+              <h2 className="text-2xl font-semibold text-brand-ink font-heading">
                 Your Characters
                 {!loading && (
                   <span className="text-lg text-warm-gray ml-2">
@@ -251,7 +251,7 @@ export default function CharactersPage() {
             {/* Loading State */}
             {loading && (
               <div className="flex flex-col items-center justify-center py-16">
-                <Loader2 className="w-12 h-12 text-moss-green animate-spin mb-4" />
+                <Loader2 className="w-12 h-12 text-brand-ink animate-spin mb-4" />
                 <p className="text-stone-gray">Loading your characters...</p>
               </div>
             )}
@@ -295,12 +295,12 @@ export default function CharactersPage() {
           {/* Character Stats (if characters exist) */}
           {!loading && characters.length > 0 && (
             <section className="glass-panel p-6">
-              <h3 className="text-lg font-semibold text-moss-green mb-4">
+              <h3 className="text-lg font-semibold text-brand-ink mb-4">
                 Quick Stats
               </h3>
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                 <div className="text-center p-4 rounded-lg bg-moss-green/5">
-                  <p className="text-3xl font-bold text-moss-green">
+                  <p className="text-3xl font-bold text-brand-ink">
                     {characters.filter((c) => c.campaignId).length}
                   </p>
                   <p className="text-sm text-warm-gray mt-1">Assigned to Campaigns</p>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -81,7 +81,7 @@ export default function DashboardPage() {
                 <img src={mascotUrl} alt="" className="w-10 h-10 object-contain" />
               </div>
               <div>
-                <h1 className="text-3xl font-bold text-moss-green font-heading">
+                <h1 className="text-3xl font-bold text-brand-ink font-heading">
                   CozyVTT
                 </h1>
                 <p className="text-sm text-warm-gray">
@@ -109,7 +109,7 @@ export default function DashboardPage() {
                   variant="secondary" className="flex items-center gap-2"
                   aria-label="Go to Admin Panel"
                 >
-                  <Shield className="w-4 h-4 text-moss-green" aria-hidden="true" />
+                  <Shield className="w-4 h-4 text-brand-ink" aria-hidden="true" />
                   <span className="hidden sm:inline">Admin</span>
                 </Button>
               )}
@@ -136,7 +136,7 @@ export default function DashboardPage() {
                     className="w-full h-full object-cover"
                   />
                 ) : (
-                  <User className="w-6 h-6 text-moss-green" aria-hidden="true" />
+                  <User className="w-6 h-6 text-brand-ink" aria-hidden="true" />
                 )}
               </button>
             </div>
@@ -157,7 +157,7 @@ export default function DashboardPage() {
                     <User className="w-6 h-6 text-spirit-purple" />
                   </div>
                   <div>
-                    <h2 className="text-xl font-semibold text-moss-green font-heading">
+                    <h2 className="text-xl font-semibold text-brand-ink font-heading">
                       Your Characters
                     </h2>
                     <p className="text-sm text-warm-gray">
@@ -210,7 +210,7 @@ export default function DashboardPage() {
                                 className="w-full h-full object-cover"
                               />
                             ) : (
-                              <User className="w-5 h-5 text-moss-green" />
+                              <User className="w-5 h-5 text-brand-ink" />
                             )}
                           </div>
                           <div className="flex-1 min-w-0">
@@ -255,7 +255,7 @@ export default function DashboardPage() {
                     <FolderOpen className="w-6 h-6 text-warm-amber" />
                   </div>
                   <div>
-                    <h2 className="text-xl font-semibold text-moss-green font-heading">
+                    <h2 className="text-xl font-semibold text-brand-ink font-heading">
                       Asset Library
                     </h2>
                     <p className="text-sm text-warm-gray">
@@ -279,7 +279,7 @@ export default function DashboardPage() {
                   onClick={() => navigate('/assets')}
                 >
                   <FolderOpen className="w-8 h-8 mx-auto mb-2 text-warm-amber/60" />
-                  <p className="text-sm font-medium text-moss-green mb-1">
+                  <p className="text-sm font-medium text-brand-ink mb-1">
                     Manage Your Assets
                   </p>
                   <p className="text-xs text-warm-gray">
@@ -295,10 +295,10 @@ export default function DashboardPage() {
             <section className="glass-panel p-6">
               <div className="flex items-center gap-3 mb-4">
                 <div className="p-2 rounded-lg bg-moss-green/10">
-                  <Mail className="w-6 h-6 text-moss-green" />
+                  <Mail className="w-6 h-6 text-brand-ink" />
                 </div>
                 <div>
-                  <h2 className="text-xl font-semibold text-moss-green font-heading">
+                  <h2 className="text-xl font-semibold text-brand-ink font-heading">
                     Pending Invitations
                   </h2>
                   <p className="text-sm text-warm-gray">
@@ -314,7 +314,7 @@ export default function DashboardPage() {
                     className="p-4 rounded-lg bg-parchment/50 border border-moss-green/20 hover:border-moss-green/40 transition-colors cursor-pointer"
                     onClick={() => setSelectedInvitation(invitation)}
                   >
-                    <h3 className="font-semibold text-moss-green mb-1">
+                    <h3 className="font-semibold text-brand-ink mb-1">
                       {invitation.campaign?.name}
                     </h3>
                     {invitation.campaign?.description && (
@@ -326,7 +326,7 @@ export default function DashboardPage() {
                       <span>
                         DM: {invitation.campaign?.owner?.displayName}
                       </span>
-                      <button className="text-moss-green hover:underline font-medium">
+                      <button className="text-brand-ink hover:underline font-medium">
                         View Invitation →
                       </button>
                     </div>
@@ -339,7 +339,7 @@ export default function DashboardPage() {
           {/* Campaigns Section */}
           <section>
             <div className="flex items-center justify-between mb-6">
-              <h2 className="text-2xl font-semibold text-moss-green font-heading">
+              <h2 className="text-2xl font-semibold text-brand-ink font-heading">
                 Your Campaigns
               </h2>
               <div className="flex items-center gap-2">
@@ -362,10 +362,10 @@ export default function DashboardPage() {
 
             {/* Error Message */}
             {error && !loading && (
-              <div className="mb-6 bg-red-500/10 border border-red-500/20 rounded-lg p-4 flex items-start gap-3">
-                <AlertCircle className="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" />
+              <div className="mb-6 bg-danger/10 border border-danger/20 rounded-lg p-4 flex items-start gap-3">
+                <AlertCircle className="w-5 h-5 text-danger-ink flex-shrink-0 mt-0.5" />
                 <div className="flex-1">
-                  <p className="text-sm text-red-700 font-medium">{error}</p>
+                  <p className="text-sm text-danger-ink font-medium">{error}</p>
                 </div>
                 <Button
                   onClick={loadData}
@@ -392,7 +392,7 @@ export default function DashboardPage() {
                   <div className="mb-4 inline-block p-4 rounded-full bg-moss-green/10">
                     <img src={mascotUrl} alt="" className="w-12 h-12 object-contain" />
                   </div>
-                  <h3 className="text-xl font-semibold text-moss-green mb-2">
+                  <h3 className="text-xl font-semibold text-brand-ink mb-2">
                     No campaigns yet
                   </h3>
                   <p className="text-warm-gray mb-6">
@@ -427,12 +427,12 @@ export default function DashboardPage() {
           {/* Campaign Stats (if campaigns exist) */}
           {!loading && campaigns.length > 0 && (
             <section className="glass-panel p-6">
-              <h3 className="text-lg font-semibold text-moss-green mb-4">
+              <h3 className="text-lg font-semibold text-brand-ink mb-4">
                 Quick Stats
               </h3>
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                 <div className="text-center p-4 rounded-lg bg-moss-green/5">
-                  <p className="text-3xl font-bold text-moss-green">
+                  <p className="text-3xl font-bold text-brand-ink">
                     {campaigns.filter(c => getUserRole(c) === CampaignRole.DM).length}
                   </p>
                   <p className="text-sm text-warm-gray mt-1">Campaigns as DM</p>

--- a/frontend/src/pages/MFASetupPage.tsx
+++ b/frontend/src/pages/MFASetupPage.tsx
@@ -111,10 +111,10 @@ export default function MFASetupPage() {
         <div className="text-center">
           <div className="flex justify-center mb-4">
             <div className="bg-moss-green/10 rounded-full p-3">
-              <Shield className="w-8 h-8 text-moss-green" />
+              <Shield className="w-8 h-8 text-brand-ink" />
             </div>
           </div>
-          <h1 className="text-2xl font-bold text-moss-green font-heading">
+          <h1 className="text-2xl font-bold text-brand-ink font-heading">
             Set Up Two-Factor Authentication
           </h1>
           <p className="mt-1 text-sm text-warm-gray">
@@ -127,16 +127,16 @@ export default function MFASetupPage() {
         {/* ── Loading ── */}
         {step === 'loading' && (
           <div className="flex items-center justify-center py-12">
-            <Loader2 className="w-8 h-8 text-moss-green animate-spin" />
+            <Loader2 className="w-8 h-8 text-brand-ink animate-spin" />
           </div>
         )}
 
         {/* ── Error ── */}
         {step === 'error' && (
           <div className="space-y-4">
-            <div className="p-4 rounded-lg bg-red-50 border border-red-200 flex gap-3">
-              <AlertTriangle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
-              <p className="text-sm text-red-700">{initError}</p>
+            <div className="p-4 rounded-lg bg-danger/10 border border-danger/30 flex gap-3">
+              <AlertTriangle className="w-5 h-5 text-danger-ink flex-shrink-0 mt-0.5" />
+              <p className="text-sm text-danger-ink">{initError}</p>
             </div>
             <Button onClick={() => navigate('/profile')} variant="secondary" className="w-full">
               Back to Profile
@@ -165,14 +165,14 @@ export default function MFASetupPage() {
             <div>
               <p className="text-xs font-medium text-stone-gray mb-1.5">Manual entry key</p>
               <div className="flex items-center gap-2 p-3 rounded-lg bg-parchment/60 border border-moss-green/15">
-                <code className="flex-1 text-sm font-mono text-moss-green break-all">{secret}</code>
+                <code className="flex-1 text-sm font-mono text-brand-ink break-all">{secret}</code>
                 <button
                   onClick={copySecret}
                   className="flex-shrink-0 p-1.5 rounded hover:bg-moss-green/10 transition-colors"
                   title="Copy secret"
                 >
                   {secretCopied ? (
-                    <CheckCircle className="w-4 h-4 text-moss-green" />
+                    <CheckCircle className="w-4 h-4 text-brand-ink" />
                   ) : (
                     <Copy className="w-4 h-4 text-stone-gray" />
                   )}
@@ -198,13 +198,13 @@ export default function MFASetupPage() {
                   }}
                   placeholder="000000"
                   className={`input-cozy w-full text-center text-2xl tracking-widest font-mono ${
-                    tokenError ? 'border-red-400 focus:ring-red-400' : ''
+                    tokenError ? 'border-danger/60 focus:ring-danger' : ''
                   }`}
                   autoFocus
                   autoComplete="one-time-code"
                 />
                 {tokenError && (
-                  <p className="mt-1 text-xs text-red-600">{tokenError}</p>
+                  <p className="mt-1 text-xs text-danger-ink">{tokenError}</p>
                 )}
               </div>
 
@@ -243,11 +243,11 @@ export default function MFASetupPage() {
         {step === 'backup-codes' && (
           <div className="space-y-5">
             {/* Success banner */}
-            <div className="flex items-center gap-3 p-4 rounded-lg bg-green-50 border border-green-200">
-              <CheckCircle className="w-5 h-5 text-green-600 flex-shrink-0" />
+            <div className="flex items-center gap-3 p-4 rounded-lg bg-success/10 border border-success/30">
+              <CheckCircle className="w-5 h-5 text-success-ink flex-shrink-0" />
               <div>
-                <p className="text-sm font-semibold text-green-800">MFA Enabled Successfully</p>
-                <p className="text-xs text-green-700 mt-0.5">
+                <p className="text-sm font-semibold text-success-ink">MFA Enabled Successfully</p>
+                <p className="text-xs text-success-ink mt-0.5">
                   Your account is now protected with two-factor authentication.
                 </p>
               </div>
@@ -271,7 +271,7 @@ export default function MFASetupPage() {
                 </p>
                 <button
                   onClick={copyBackupCodes}
-                  className="flex items-center gap-1 text-xs text-moss-green hover:text-moss-green/80 transition-colors"
+                  className="flex items-center gap-1 text-xs text-brand-ink hover:text-brand-ink/80 transition-colors"
                 >
                   {codesCopied ? (
                     <>
@@ -290,7 +290,7 @@ export default function MFASetupPage() {
                 {backupCodes.map((code, i) => (
                   <code
                     key={i}
-                    className="text-sm font-mono text-moss-green text-center py-1.5 px-2 rounded bg-paper/60 border border-moss-green/10"
+                    className="text-sm font-mono text-brand-ink text-center py-1.5 px-2 rounded bg-paper/60 border border-moss-green/10"
                   >
                     {code.slice(0, 4)}-{code.slice(4)}
                   </code>
@@ -304,7 +304,7 @@ export default function MFASetupPage() {
                 type="checkbox"
                 checked={codesAcknowledged}
                 onChange={(e) => setCodesAcknowledged(e.target.checked)}
-                className="mt-0.5 w-4 h-4 rounded border-moss-green/30 text-moss-green focus:ring-moss-green/50"
+                className="mt-0.5 w-4 h-4 rounded border-moss-green/30 text-brand-ink focus:ring-moss-green/50"
               />
               <span className="text-sm text-stone-gray">
                 I have saved my backup codes in a secure location.

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -180,7 +180,7 @@ function AvatarCropModal({ imageSrc, onConfirm, onClose }: AvatarCropModalProps)
       <div className="bg-soft-cream border border-moss-green/30 rounded-xl shadow-2xl w-full max-w-sm">
         {/* Header */}
         <div className="flex items-center justify-between px-5 pt-5 pb-3 border-b border-moss-green/15">
-          <h3 className="text-base font-semibold text-moss-green">Crop Avatar</h3>
+          <h3 className="text-base font-semibold text-brand-ink">Crop Avatar</h3>
           <p className="text-xs text-warm-gray flex items-center gap-1">
             <Move className="w-3 h-3" /> Drag to reposition
           </p>
@@ -202,7 +202,7 @@ function AvatarCropModal({ imageSrc, onConfirm, onClose }: AvatarCropModalProps)
               />
               {!imgLoaded && (
                 <div className="absolute inset-0 flex items-center justify-center bg-moss-green/10">
-                  <Loader2 className="w-8 h-8 text-moss-green animate-spin" />
+                  <Loader2 className="w-8 h-8 text-brand-ink animate-spin" />
                 </div>
               )}
             </div>
@@ -260,9 +260,9 @@ function SaveBar({
 }) {
   return (
     <div className="flex items-center gap-3 pt-4 border-t border-moss-green/10 mt-4">
-      {error && <p className="text-xs text-red-600 flex-1">{error}</p>}
+      {error && <p className="text-xs text-danger-ink flex-1">{error}</p>}
       {success && (
-        <p className="text-xs text-moss-green flex items-center gap-1 flex-1">
+        <p className="text-xs text-brand-ink flex items-center gap-1 flex-1">
           <CheckCircle className="w-3.5 h-3.5" /> {success}
         </p>
       )}
@@ -589,13 +589,13 @@ export default function ProfilePage() {
         <div className="max-w-4xl mx-auto px-4 py-5 flex items-center gap-4">
           <button
             onClick={() => navigate('/dashboard')}
-            className="p-2 rounded-lg hover:bg-moss-green/10 transition-colors text-moss-green"
+            className="p-2 rounded-lg hover:bg-moss-green/10 transition-colors text-brand-ink"
             aria-label="Back to dashboard"
           >
             <ChevronLeft className="w-5 h-5" aria-hidden="true" />
           </button>
           <div>
-            <h1 className="text-2xl font-bold text-moss-green font-heading">Profile & Settings</h1>
+            <h1 className="text-2xl font-bold text-brand-ink font-heading">Profile & Settings</h1>
             <p className="text-sm text-warm-gray">Manage your account and preferences</p>
           </div>
         </div>
@@ -606,7 +606,7 @@ export default function ProfilePage() {
         {/* ── Profile Information ── */}
         <section className="glass-panel p-6">
           <div className="flex items-center justify-between mb-5">
-            <h2 className="text-xl font-semibold text-moss-green">Profile Information</h2>
+            <h2 className="text-xl font-semibold text-brand-ink">Profile Information</h2>
             {!editingProfile && (
               <Button onClick={startEditProfile} variant="secondary" className="text-sm py-1.5 px-3">
                 Edit
@@ -629,7 +629,7 @@ export default function ProfilePage() {
                   />
                 ) : (
                   <div className="w-20 h-20 rounded-full bg-moss-green/20 flex items-center justify-center border-2 border-moss-green/30">
-                    <User className="w-9 h-9 text-moss-green/60" />
+                    <User className="w-9 h-9 text-brand-ink/60" />
                   </div>
                 )}
                 <div className="absolute inset-0 rounded-full bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
@@ -647,9 +647,9 @@ export default function ProfilePage() {
                 onChange={handleAvatarFileChange}
                 className="hidden"
               />
-              {avatarError && <p className="mt-1 text-xs text-red-600 max-w-[5rem]">{avatarError}</p>}
+              {avatarError && <p className="mt-1 text-xs text-danger-ink max-w-[5rem]">{avatarError}</p>}
               {avatarSuccess && (
-                <p className="mt-1 text-xs text-moss-green flex items-center gap-1">
+                <p className="mt-1 text-xs text-brand-ink flex items-center gap-1">
                   <CheckCircle className="w-3 h-3" /> {avatarSuccess}
                 </p>
               )}
@@ -673,21 +673,21 @@ export default function ProfilePage() {
                     <p className="text-xs text-warm-gray/70 mt-0.5 text-right">{displayName.length}/50</p>
                   </>
                 ) : (
-                  <p className="text-moss-green font-medium">{user?.displayName}</p>
+                  <p className="text-brand-ink font-medium">{user?.displayName}</p>
                 )}
               </div>
 
               {/* Email (read-only) */}
               <div>
                 <label className="block text-xs font-medium text-stone-gray mb-1">Email</label>
-                <p className="text-moss-green">{user?.email}</p>
+                <p className="text-brand-ink">{user?.email}</p>
                 <p className="text-xs text-warm-gray/70">Email cannot be changed.</p>
               </div>
 
               {/* Role (read-only) */}
               <div>
                 <label className="block text-xs font-medium text-stone-gray mb-1">Platform Role</label>
-                <span className="inline-block px-2 py-0.5 rounded text-xs font-medium bg-moss-green/10 text-moss-green border border-moss-green/20">
+                <span className="inline-block px-2 py-0.5 rounded text-xs font-medium bg-moss-green/10 text-brand-ink border border-moss-green/20">
                   {user?.platformRole}
                 </span>
               </div>
@@ -732,7 +732,7 @@ export default function ProfilePage() {
 
         {/* ── Security ── */}
         <section className="glass-panel p-6 space-y-6">
-          <h2 className="text-xl font-semibold text-moss-green">Security</h2>
+          <h2 className="text-xl font-semibold text-brand-ink">Security</h2>
 
           {/* MFA */}
           <div>
@@ -740,13 +740,13 @@ export default function ProfilePage() {
           </div>
 
           <div className="border-t border-moss-green/10 pt-6">
-            <h3 className="text-sm font-semibold text-moss-green mb-4">Change Password</h3>
+            <h3 className="text-sm font-semibold text-brand-ink mb-4">Change Password</h3>
             <form onSubmit={handleChangePassword} className="space-y-3 max-w-sm">
               {pwError && (
-                <div className="p-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">{pwError}</div>
+                <div className="p-3 rounded-lg bg-danger/10 border border-danger/30 text-sm text-danger-ink">{pwError}</div>
               )}
               {pwSuccess && (
-                <div className="p-3 rounded-lg bg-green-50 border border-green-200 text-sm text-green-700 flex items-center gap-2">
+                <div className="p-3 rounded-lg bg-success/10 border border-success/30 text-sm text-success-ink flex items-center gap-2">
                   <CheckCircle className="w-4 h-4" /> {pwSuccess}
                 </div>
               )}
@@ -801,12 +801,12 @@ export default function ProfilePage() {
                   type="password"
                   value={pwConfirm}
                   onChange={(e) => setPwConfirm(e.target.value)}
-                  className={`input-cozy w-full ${pwConfirm && pwNew !== pwConfirm ? 'border-red-400' : ''}`}
+                  className={`input-cozy w-full ${pwConfirm && pwNew !== pwConfirm ? 'border-danger/60' : ''}`}
                   placeholder="Repeat new password"
                   autoComplete="new-password"
                 />
                 {pwConfirm && pwNew !== pwConfirm && (
-                  <p className="text-xs text-red-600 mt-0.5">Passwords do not match</p>
+                  <p className="text-xs text-danger-ink mt-0.5">Passwords do not match</p>
                 )}
               </div>
 
@@ -826,7 +826,7 @@ export default function ProfilePage() {
         <section className="glass-panel p-6 space-y-6">
           <div className="flex items-center justify-between">
             <div>
-              <h2 className="text-xl font-semibold text-moss-green">Appearance</h2>
+              <h2 className="text-xl font-semibold text-brand-ink">Appearance</h2>
               <p className="text-xs text-warm-gray mt-0.5">
                 Pick your theme and font — saved automatically to your account.
               </p>
@@ -834,7 +834,7 @@ export default function ProfilePage() {
             <div className="flex items-center gap-2">
               {prefsSaving && <Loader2 className="w-3.5 h-3.5 animate-spin text-warm-gray" />}
               {prefsSaved && !prefsSaving && (
-                <p className="text-xs text-moss-green flex items-center gap-1">
+                <p className="text-xs text-brand-ink flex items-center gap-1">
                   <CheckCircle className="w-3.5 h-3.5" /> Saved
                 </p>
               )}
@@ -842,7 +842,7 @@ export default function ProfilePage() {
           </div>
 
           {prefsError && (
-            <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg p-3 text-sm">
+            <div className="bg-danger/10 border border-danger/30 text-danger-ink rounded-lg p-3 text-sm">
               {prefsError}
             </div>
           )}
@@ -876,13 +876,13 @@ export default function ProfilePage() {
         </section>
 
         {/* ── Danger Zone ── */}
-        <section className="glass-panel p-6 border-2 border-red-200/60">
-          <h2 className="text-xl font-semibold text-red-600 mb-5">Danger Zone</h2>
+        <section className="glass-panel p-6 border-2 border-danger/60">
+          <h2 className="text-xl font-semibold text-danger-ink mb-5">Danger Zone</h2>
           <div className="space-y-4">
             {/* Logout */}
-            <div className="flex items-center justify-between py-3 border-b border-red-100">
+            <div className="flex items-center justify-between py-3 border-b border-danger/30">
               <div>
-                <h3 className="text-sm font-medium text-moss-green">Sign Out</h3>
+                <h3 className="text-sm font-medium text-brand-ink">Sign Out</h3>
                 <p className="text-xs text-warm-gray">End your current session.</p>
               </div>
               <Button onClick={handleLogout} variant="secondary" className="text-sm py-1.5 px-3">
@@ -893,7 +893,7 @@ export default function ProfilePage() {
             {/* Delete account */}
             <div className="flex items-start justify-between">
               <div>
-                <h3 className="text-sm font-medium text-red-700">Delete Account</h3>
+                <h3 className="text-sm font-medium text-danger-ink">Delete Account</h3>
                 <p className="text-xs text-warm-gray">
                   Permanently delete your account and all data. This cannot be undone.
                 </p>
@@ -901,7 +901,7 @@ export default function ProfilePage() {
               {!deleteConfirmOpen && (
                 <button
                   onClick={() => setDeleteConfirmOpen(true)}
-                  className="ml-4 flex-shrink-0 text-sm py-1.5 px-3 rounded-lg border border-red-300 text-red-600 hover:bg-red-50 transition-colors font-medium"
+                  className="ml-4 flex-shrink-0 text-sm py-1.5 px-3 rounded-lg border border-danger/30 text-danger-ink hover:bg-danger/10 transition-colors font-medium"
                 >
                   Delete Account
                 </button>
@@ -909,10 +909,10 @@ export default function ProfilePage() {
             </div>
 
             {deleteConfirmOpen && (
-              <form onSubmit={handleDeleteAccount} className="space-y-3 p-4 rounded-lg bg-red-50 border border-red-200">
+              <form onSubmit={handleDeleteAccount} className="space-y-3 p-4 rounded-lg bg-danger/10 border border-danger/30">
                 <div className="flex items-start gap-3">
-                  <AlertTriangle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
-                  <div className="text-sm text-red-800 space-y-1">
+                  <AlertTriangle className="w-5 h-5 text-danger-ink flex-shrink-0 mt-0.5" />
+                  <div className="text-sm text-danger-ink space-y-1">
                     <p className="font-semibold">This will permanently delete:</p>
                     <ul className="list-disc list-inside text-xs space-y-0.5">
                       <li>Your account and profile</li>
@@ -923,30 +923,30 @@ export default function ProfilePage() {
                 </div>
 
                 {deleteError && (
-                  <p className="text-sm text-red-700 bg-red-100 border border-red-300 rounded p-2">{deleteError}</p>
+                  <p className="text-sm text-danger-ink bg-danger/10 border border-danger/30 rounded p-2">{deleteError}</p>
                 )}
 
                 <div>
-                  <label className="block text-xs font-medium text-red-800 mb-1">
+                  <label className="block text-xs font-medium text-danger-ink mb-1">
                     Type <strong>DELETE</strong> to confirm
                   </label>
                   <input
                     type="text"
                     value={deleteConfirmText}
                     onChange={(e) => setDeleteConfirmText(e.target.value)}
-                    className="input-cozy w-full border-red-300 focus:ring-red-400"
+                    className="input-cozy w-full border-danger/30 focus:ring-danger"
                     placeholder="DELETE"
                     autoComplete="off"
                   />
                 </div>
 
                 <div>
-                  <label className="block text-xs font-medium text-red-800 mb-1">Your Password</label>
+                  <label className="block text-xs font-medium text-danger-ink mb-1">Your Password</label>
                   <input
                     type="password"
                     value={deletePassword}
                     onChange={(e) => setDeletePassword(e.target.value)}
-                    className="input-cozy w-full border-red-300 focus:ring-red-400"
+                    className="input-cozy w-full border-danger/30 focus:ring-danger"
                     placeholder="Enter your password"
                     autoComplete="current-password"
                   />
@@ -964,7 +964,7 @@ export default function ProfilePage() {
                   <button
                     type="submit"
                     disabled={deleting || deleteConfirmText !== 'DELETE' || !deletePassword}
-                    className="flex-1 flex items-center justify-center gap-2 py-2 px-4 rounded-lg bg-red-600 hover:bg-red-700 text-white text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="flex-1 flex items-center justify-center gap-2 py-2 px-4 rounded-lg bg-danger hover:bg-danger text-white text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {deleting && <Loader2 className="w-4 h-4 animate-spin" />}
                     {deleting ? 'Deleting...' : 'Delete My Account'}

--- a/frontend/src/pages/SetupWizardPage.tsx
+++ b/frontend/src/pages/SetupWizardPage.tsx
@@ -258,7 +258,7 @@ export default function SetupWizardPage() {
         aria-live="polite"
         aria-label="Checking setup status"
       >
-        <Loader2 className="w-8 h-8 text-moss-green animate-spin" aria-hidden="true" />
+        <Loader2 className="w-8 h-8 text-brand-ink animate-spin" aria-hidden="true" />
       </div>
     );
   }
@@ -271,7 +271,7 @@ export default function SetupWizardPage() {
           <div className="flex justify-center mb-4">
             <img src={mascotUrl} alt="CozyVTT" className="w-20 h-20 object-contain animate-pulse-soft" />
           </div>
-          <h1 className="text-4xl font-bold text-moss-green font-heading">
+          <h1 className="text-4xl font-bold text-brand-ink font-heading">
             CozyVTT Setup
           </h1>
           <p className="mt-2 text-warm-gray">
@@ -394,11 +394,11 @@ function Step1Welcome() {
     <div className="space-y-6 text-center">
       <div className="flex justify-center gap-4">
         <Shield className="w-12 h-12 text-spirit-purple" />
-        <Settings className="w-12 h-12 text-moss-green" />
+        <Settings className="w-12 h-12 text-brand-ink" />
       </div>
 
       <div>
-        <h2 className="text-2xl font-bold text-moss-green mb-3">
+        <h2 className="text-2xl font-bold text-brand-ink mb-3">
           Welcome to CozyVTT!
         </h2>
         <p className="text-stone-gray max-w-xl mx-auto">
@@ -408,18 +408,18 @@ function Step1Welcome() {
       </div>
 
       <div className="glass-panel p-6 text-left space-y-4 bg-warm-amber/5">
-        <h3 className="font-semibold text-moss-green">What we'll set up:</h3>
+        <h3 className="font-semibold text-brand-ink">What we'll set up:</h3>
         <ul className="space-y-2 text-sm text-stone-gray">
           <li className="flex items-start gap-2">
-            <CheckCircle className="w-5 h-5 text-moss-green flex-shrink-0 mt-0.5" />
+            <CheckCircle className="w-5 h-5 text-brand-ink flex-shrink-0 mt-0.5" />
             <span>Create your administrator account</span>
           </li>
           <li className="flex items-start gap-2">
-            <CheckCircle className="w-5 h-5 text-moss-green flex-shrink-0 mt-0.5" />
+            <CheckCircle className="w-5 h-5 text-brand-ink flex-shrink-0 mt-0.5" />
             <span>Configure basic system settings</span>
           </li>
           <li className="flex items-start gap-2">
-            <CheckCircle className="w-5 h-5 text-moss-green flex-shrink-0 mt-0.5" />
+            <CheckCircle className="w-5 h-5 text-brand-ink flex-shrink-0 mt-0.5" />
             <span>Complete the installation process</span>
           </li>
         </ul>
@@ -447,7 +447,7 @@ function Step2AdminAccount({ data, setData, fieldErrors, passwordStrength }: Ste
   return (
     <div className="space-y-6">
       <div className="text-center">
-        <h2 className="text-2xl font-bold text-moss-green mb-2">
+        <h2 className="text-2xl font-bold text-brand-ink mb-2">
           Create Admin Account
         </h2>
         <p className="text-sm text-stone-gray">
@@ -458,7 +458,7 @@ function Step2AdminAccount({ data, setData, fieldErrors, passwordStrength }: Ste
       <div className="space-y-4">
         {/* Display Name */}
         <div>
-          <label htmlFor="displayName" className="block text-sm font-medium text-moss-green mb-1">
+          <label htmlFor="displayName" className="block text-sm font-medium text-brand-ink mb-1">
             Display Name
           </label>
           <input
@@ -479,7 +479,7 @@ function Step2AdminAccount({ data, setData, fieldErrors, passwordStrength }: Ste
 
         {/* Email */}
         <div>
-          <label htmlFor="email" className="block text-sm font-medium text-moss-green mb-1">
+          <label htmlFor="email" className="block text-sm font-medium text-brand-ink mb-1">
             Email Address
           </label>
           <input
@@ -499,7 +499,7 @@ function Step2AdminAccount({ data, setData, fieldErrors, passwordStrength }: Ste
 
         {/* Password */}
         <div>
-          <label htmlFor="password" className="block text-sm font-medium text-moss-green mb-1">
+          <label htmlFor="password" className="block text-sm font-medium text-brand-ink mb-1">
             Password
           </label>
           <input
@@ -524,10 +524,10 @@ function Step2AdminAccount({ data, setData, fieldErrors, passwordStrength }: Ste
                 <span
                   className={`text-xs font-medium ${
                     passwordStrength.color === 'green'
-                      ? 'text-green-600'
+                      ? 'text-success-ink'
                       : passwordStrength.color === 'yellow'
-                      ? 'text-yellow-600'
-                      : 'text-red-600'
+                      ? 'text-warning-ink'
+                      : 'text-danger-ink'
                   }`}
                 >
                   {passwordStrength.label}
@@ -537,10 +537,10 @@ function Step2AdminAccount({ data, setData, fieldErrors, passwordStrength }: Ste
                 <div
                   className={`h-1.5 rounded-full transition-all ${
                     passwordStrength.color === 'green'
-                      ? 'bg-green-600'
+                      ? 'bg-success'
                       : passwordStrength.color === 'yellow'
-                      ? 'bg-yellow-600'
-                      : 'bg-red-600'
+                      ? 'bg-warning'
+                      : 'bg-danger'
                   }`}
                   style={{ width: `${(passwordStrength.score / 10) * 100}%` }}
                 ></div>
@@ -553,7 +553,7 @@ function Step2AdminAccount({ data, setData, fieldErrors, passwordStrength }: Ste
         <div>
           <label
             htmlFor="confirmPassword"
-            className="block text-sm font-medium text-moss-green mb-1"
+            className="block text-sm font-medium text-brand-ink mb-1"
           >
             Confirm Password
           </label>
@@ -608,7 +608,7 @@ function Step3SystemConfig({ data, setData, fieldErrors }: Step3Props) {
   return (
     <div className="space-y-6">
       <div className="text-center">
-        <h2 className="text-2xl font-bold text-moss-green mb-2">
+        <h2 className="text-2xl font-bold text-brand-ink mb-2">
           System Configuration
         </h2>
         <p className="text-sm text-stone-gray">
@@ -621,7 +621,7 @@ function Step3SystemConfig({ data, setData, fieldErrors }: Step3Props) {
         <div>
           <label
             htmlFor="instanceName"
-            className="block text-sm font-medium text-moss-green mb-1"
+            className="block text-sm font-medium text-brand-ink mb-1"
           >
             Instance Name
           </label>
@@ -645,7 +645,7 @@ function Step3SystemConfig({ data, setData, fieldErrors }: Step3Props) {
 
         {/* Timezone */}
         <div>
-          <label htmlFor="timezone" className="block text-sm font-medium text-moss-green mb-1">
+          <label htmlFor="timezone" className="block text-sm font-medium text-brand-ink mb-1">
             Timezone
           </label>
           <select
@@ -685,7 +685,7 @@ function Step3SystemConfig({ data, setData, fieldErrors }: Step3Props) {
             <div className="flex-1">
               <label
                 htmlFor="enableRegistration"
-                className="block text-sm font-medium text-moss-green cursor-pointer"
+                className="block text-sm font-medium text-brand-ink cursor-pointer"
               >
                 Enable Public Registration
               </label>
@@ -717,7 +717,7 @@ function Step4Review({ adminData, systemConfig }: Step4Props) {
   return (
     <div className="space-y-6">
       <div className="text-center">
-        <h2 className="text-2xl font-bold text-moss-green mb-2">
+        <h2 className="text-2xl font-bold text-brand-ink mb-2">
           Review & Confirm
         </h2>
         <p className="text-sm text-stone-gray">
@@ -728,18 +728,18 @@ function Step4Review({ adminData, systemConfig }: Step4Props) {
       <div className="space-y-4">
         {/* Admin Account */}
         <div className="glass-panel p-4 bg-moss-green/5">
-          <h3 className="font-semibold text-moss-green mb-3 flex items-center gap-2">
+          <h3 className="font-semibold text-brand-ink mb-3 flex items-center gap-2">
             <Shield className="w-5 h-5" />
             Administrator Account
           </h3>
           <dl className="space-y-2 text-sm">
             <div className="flex justify-between">
               <dt className="text-warm-gray">Display Name:</dt>
-              <dd className="text-moss-green font-medium">{adminData.displayName}</dd>
+              <dd className="text-brand-ink font-medium">{adminData.displayName}</dd>
             </div>
             <div className="flex justify-between">
               <dt className="text-warm-gray">Email:</dt>
-              <dd className="text-moss-green font-medium">{adminData.email}</dd>
+              <dd className="text-brand-ink font-medium">{adminData.email}</dd>
             </div>
             <div className="flex justify-between">
               <dt className="text-warm-gray">Password:</dt>
@@ -750,18 +750,18 @@ function Step4Review({ adminData, systemConfig }: Step4Props) {
 
         {/* System Configuration */}
         <div className="glass-panel p-4 bg-warm-amber/5">
-          <h3 className="font-semibold text-moss-green mb-3 flex items-center gap-2">
+          <h3 className="font-semibold text-brand-ink mb-3 flex items-center gap-2">
             <Settings className="w-5 h-5" />
             System Configuration
           </h3>
           <dl className="space-y-2 text-sm">
             <div className="flex justify-between">
               <dt className="text-warm-gray">Instance Name:</dt>
-              <dd className="text-moss-green font-medium">{systemConfig.instanceName}</dd>
+              <dd className="text-brand-ink font-medium">{systemConfig.instanceName}</dd>
             </div>
             <div className="flex justify-between">
               <dt className="text-warm-gray">Timezone:</dt>
-              <dd className="text-moss-green font-medium">{systemConfig.timezone}</dd>
+              <dd className="text-brand-ink font-medium">{systemConfig.timezone}</dd>
             </div>
             <div className="flex justify-between">
               <dt className="text-warm-gray">Public Registration:</dt>
@@ -779,7 +779,7 @@ function Step4Review({ adminData, systemConfig }: Step4Props) {
         {/* Confirmation Message */}
         <div className="glass-panel p-4 border-2 border-moss-green/30">
           <p className="text-sm text-stone-gray text-center">
-            Click <span className="font-medium text-moss-green">Complete Setup</span> to
+            Click <span className="font-medium text-brand-ink">Complete Setup</span> to
             create your admin account and finish the installation. You will be
             automatically logged in and redirected to the dashboard.
           </p>

--- a/frontend/src/pages/auth/ChangePasswordPage.tsx
+++ b/frontend/src/pages/auth/ChangePasswordPage.tsx
@@ -79,9 +79,9 @@ export default function ChangePasswordPage() {
       <main id="main-content" className="glass-panel max-w-md w-full p-8 space-y-6">
         <div className="text-center">
           <div className="flex justify-center mb-3">
-            <KeyRound className="w-10 h-10 text-moss-green/70" aria-hidden="true" />
+            <KeyRound className="w-10 h-10 text-brand-ink/70" aria-hidden="true" />
           </div>
-          <h1 className="text-2xl font-bold text-moss-green font-heading">Choose your password</h1>
+          <h1 className="text-2xl font-bold text-brand-ink font-heading">Choose your password</h1>
           <p className="mt-2 text-sm text-warm-gray">
             {user?.displayName ? `Welcome, ${user.displayName}. ` : ''}
             Your account was set up with a temporary password. Pick your own to continue — whoever
@@ -90,16 +90,16 @@ export default function ChangePasswordPage() {
         </div>
 
         {error && (
-          <div role="alert" className="flex items-start gap-2 bg-red-50 border border-red-200 rounded-lg p-3">
-            <AlertCircle className="w-4 h-4 text-red-500 mt-0.5 flex-shrink-0" />
-            <p className="text-sm text-red-700">{error}</p>
+          <div role="alert" className="flex items-start gap-2 bg-danger/10 border border-danger/30 rounded-lg p-3">
+            <AlertCircle className="w-4 h-4 text-danger-ink mt-0.5 flex-shrink-0" />
+            <p className="text-sm text-danger-ink">{error}</p>
           </div>
         )}
 
         <form onSubmit={handleSubmit} className="space-y-4" noValidate>
           {/* Current (temporary) password */}
           <div>
-            <label htmlFor="current-password" className="block text-sm font-medium text-moss-green mb-1">
+            <label htmlFor="current-password" className="block text-sm font-medium text-brand-ink mb-1">
               Temporary password
             </label>
             <input
@@ -112,19 +112,19 @@ export default function ChangePasswordPage() {
                 setCurrentPassword(e.target.value);
                 setFieldErrors((prev) => ({ ...prev, current: undefined }));
               }}
-              className={`input-cozy w-full ${fieldErrors.current ? 'border-red-400 focus:ring-red-400' : ''}`}
+              className={`input-cozy w-full ${fieldErrors.current ? 'border-danger/60 focus:ring-danger' : ''}`}
               disabled={loading}
               aria-required="true"
               aria-invalid={!!fieldErrors.current}
             />
             {fieldErrors.current && (
-              <p role="alert" className="mt-1 text-xs text-red-600">{fieldErrors.current}</p>
+              <p role="alert" className="mt-1 text-xs text-danger-ink">{fieldErrors.current}</p>
             )}
           </div>
 
           {/* New password */}
           <div>
-            <label htmlFor="new-password" className="block text-sm font-medium text-moss-green mb-1">
+            <label htmlFor="new-password" className="block text-sm font-medium text-brand-ink mb-1">
               New password
             </label>
             <input
@@ -136,14 +136,14 @@ export default function ChangePasswordPage() {
                 setPassword(e.target.value);
                 setFieldErrors((prev) => ({ ...prev, password: undefined }));
               }}
-              className={`input-cozy w-full ${fieldErrors.password ? 'border-red-400 focus:ring-red-400' : ''}`}
+              className={`input-cozy w-full ${fieldErrors.password ? 'border-danger/60 focus:ring-danger' : ''}`}
               disabled={loading}
               aria-required="true"
               aria-invalid={!!fieldErrors.password}
               aria-describedby="password-requirements"
             />
             {fieldErrors.password && (
-              <p role="alert" className="mt-1 text-xs text-red-600">{fieldErrors.password}</p>
+              <p role="alert" className="mt-1 text-xs text-danger-ink">{fieldErrors.password}</p>
             )}
           </div>
 
@@ -153,7 +153,7 @@ export default function ChangePasswordPage() {
               {PASSWORD_REQUIREMENTS.map((req, i) => (
                 <li
                   key={req.label}
-                  className={`flex items-center gap-2 text-xs ${requirementsMet[i] ? 'text-moss-green' : 'text-warm-gray'}`}
+                  className={`flex items-center gap-2 text-xs ${requirementsMet[i] ? 'text-brand-ink' : 'text-warm-gray'}`}
                 >
                   <span aria-hidden="true">{requirementsMet[i] ? '✓' : '○'}</span>
                   {req.label}
@@ -164,7 +164,7 @@ export default function ChangePasswordPage() {
 
           {/* Confirm */}
           <div>
-            <label htmlFor="confirm-password" className="block text-sm font-medium text-moss-green mb-1">
+            <label htmlFor="confirm-password" className="block text-sm font-medium text-brand-ink mb-1">
               Confirm new password
             </label>
             <input
@@ -176,14 +176,14 @@ export default function ChangePasswordPage() {
                 setConfirmPassword(e.target.value);
                 setFieldErrors((prev) => ({ ...prev, confirm: undefined }));
               }}
-              className={`input-cozy w-full ${fieldErrors.confirm ? 'border-red-400 focus:ring-red-400' : ''}`}
+              className={`input-cozy w-full ${fieldErrors.confirm ? 'border-danger/60 focus:ring-danger' : ''}`}
               disabled={loading}
               aria-required="true"
               aria-invalid={!!fieldErrors.confirm}
               aria-describedby={fieldErrors.confirm ? 'confirm-error' : undefined}
             />
             {fieldErrors.confirm && (
-              <p id="confirm-error" role="alert" className="mt-1 text-xs text-red-600">{fieldErrors.confirm}</p>
+              <p id="confirm-error" role="alert" className="mt-1 text-xs text-danger-ink">{fieldErrors.confirm}</p>
             )}
           </div>
 
@@ -199,7 +199,7 @@ export default function ChangePasswordPage() {
         <button
           type="button"
           onClick={handleSignOut}
-          className="w-full inline-flex items-center justify-center gap-1.5 text-sm text-warm-gray hover:text-moss-green transition-colors"
+          className="w-full inline-flex items-center justify-center gap-1.5 text-sm text-warm-gray hover:text-brand-ink transition-colors"
         >
           <LogOut className="w-3.5 h-3.5" aria-hidden="true" />
           Sign out instead

--- a/frontend/src/pages/auth/ChangePasswordPage.tsx
+++ b/frontend/src/pages/auth/ChangePasswordPage.tsx
@@ -1,0 +1,210 @@
+// ============================================
+// Forced Change Password Page
+// Shown when an account is flagged `mustChangePassword` — an admin created it,
+// or an admin reset its password. Until the password is replaced the server
+// rejects every other API call, so this page has no way out except finishing.
+// Accessed via /auth/change-password
+// ============================================
+
+import { useState, FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { KeyRound, AlertCircle, LogOut } from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
+import Button from '@/components/ui/Button';
+import { PASSWORD_REQUIREMENTS } from '@/utils/validation';
+
+export default function ChangePasswordPage() {
+  const navigate = useNavigate();
+  const { changePassword, logout, user } = useAuth();
+
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<{
+    current?: string;
+    password?: string;
+    confirm?: string;
+  }>({});
+
+  const requirementsMet = PASSWORD_REQUIREMENTS.map((r) => r.test(password));
+  const allRequirementsMet = requirementsMet.every(Boolean);
+
+  const validate = (): boolean => {
+    const errors: typeof fieldErrors = {};
+    if (!currentPassword) {
+      errors.current = 'Enter the password you just signed in with';
+    }
+    if (!password) {
+      errors.password = 'Password is required';
+    } else if (!allRequirementsMet) {
+      errors.password = 'Password does not meet requirements';
+    } else if (password === currentPassword) {
+      errors.password = 'New password must differ from your current one';
+    }
+    if (!confirmPassword) {
+      errors.confirm = 'Please confirm your password';
+    } else if (password !== confirmPassword) {
+      errors.confirm = 'Passwords do not match';
+    }
+    setFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!validate()) return;
+
+    setError('');
+    setLoading(true);
+    try {
+      await changePassword(currentPassword, password);
+      navigate('/dashboard', { replace: true });
+    } catch (err: unknown) {
+      const msg = (err as { response?: { data?: { message?: string } } }).response?.data?.message;
+      setError(msg || 'Failed to change password. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSignOut = async () => {
+    await logout();
+    navigate('/auth/login', { replace: true });
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-soft-cream via-parchment to-warm-amber/20 px-4">
+      <main id="main-content" className="glass-panel max-w-md w-full p-8 space-y-6">
+        <div className="text-center">
+          <div className="flex justify-center mb-3">
+            <KeyRound className="w-10 h-10 text-moss-green/70" aria-hidden="true" />
+          </div>
+          <h1 className="text-2xl font-bold text-moss-green font-heading">Choose your password</h1>
+          <p className="mt-2 text-sm text-warm-gray">
+            {user?.displayName ? `Welcome, ${user.displayName}. ` : ''}
+            Your account was set up with a temporary password. Pick your own to continue — whoever
+            created the account can&apos;t see this one.
+          </p>
+        </div>
+
+        {error && (
+          <div role="alert" className="flex items-start gap-2 bg-red-50 border border-red-200 rounded-lg p-3">
+            <AlertCircle className="w-4 h-4 text-red-500 mt-0.5 flex-shrink-0" />
+            <p className="text-sm text-red-700">{error}</p>
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+          {/* Current (temporary) password */}
+          <div>
+            <label htmlFor="current-password" className="block text-sm font-medium text-moss-green mb-1">
+              Temporary password
+            </label>
+            <input
+              id="current-password"
+              type="password"
+              autoComplete="current-password"
+              autoFocus
+              value={currentPassword}
+              onChange={(e) => {
+                setCurrentPassword(e.target.value);
+                setFieldErrors((prev) => ({ ...prev, current: undefined }));
+              }}
+              className={`input-cozy w-full ${fieldErrors.current ? 'border-red-400 focus:ring-red-400' : ''}`}
+              disabled={loading}
+              aria-required="true"
+              aria-invalid={!!fieldErrors.current}
+            />
+            {fieldErrors.current && (
+              <p role="alert" className="mt-1 text-xs text-red-600">{fieldErrors.current}</p>
+            )}
+          </div>
+
+          {/* New password */}
+          <div>
+            <label htmlFor="new-password" className="block text-sm font-medium text-moss-green mb-1">
+              New password
+            </label>
+            <input
+              id="new-password"
+              type="password"
+              autoComplete="new-password"
+              value={password}
+              onChange={(e) => {
+                setPassword(e.target.value);
+                setFieldErrors((prev) => ({ ...prev, password: undefined }));
+              }}
+              className={`input-cozy w-full ${fieldErrors.password ? 'border-red-400 focus:ring-red-400' : ''}`}
+              disabled={loading}
+              aria-required="true"
+              aria-invalid={!!fieldErrors.password}
+              aria-describedby="password-requirements"
+            />
+            {fieldErrors.password && (
+              <p role="alert" className="mt-1 text-xs text-red-600">{fieldErrors.password}</p>
+            )}
+          </div>
+
+          {/* Requirements checklist */}
+          {password.length > 0 && (
+            <ul id="password-requirements" className="space-y-1" aria-label="Password requirements">
+              {PASSWORD_REQUIREMENTS.map((req, i) => (
+                <li
+                  key={req.label}
+                  className={`flex items-center gap-2 text-xs ${requirementsMet[i] ? 'text-moss-green' : 'text-warm-gray'}`}
+                >
+                  <span aria-hidden="true">{requirementsMet[i] ? '✓' : '○'}</span>
+                  {req.label}
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {/* Confirm */}
+          <div>
+            <label htmlFor="confirm-password" className="block text-sm font-medium text-moss-green mb-1">
+              Confirm new password
+            </label>
+            <input
+              id="confirm-password"
+              type="password"
+              autoComplete="new-password"
+              value={confirmPassword}
+              onChange={(e) => {
+                setConfirmPassword(e.target.value);
+                setFieldErrors((prev) => ({ ...prev, confirm: undefined }));
+              }}
+              className={`input-cozy w-full ${fieldErrors.confirm ? 'border-red-400 focus:ring-red-400' : ''}`}
+              disabled={loading}
+              aria-required="true"
+              aria-invalid={!!fieldErrors.confirm}
+              aria-describedby={fieldErrors.confirm ? 'confirm-error' : undefined}
+            />
+            {fieldErrors.confirm && (
+              <p id="confirm-error" role="alert" className="mt-1 text-xs text-red-600">{fieldErrors.confirm}</p>
+            )}
+          </div>
+
+          <Button
+            type="submit"
+            disabled={loading || !allRequirementsMet || password !== confirmPassword}
+            className="w-full"
+          >
+            {loading ? 'Saving...' : 'Set Password and Continue'}
+          </Button>
+        </form>
+
+        <button
+          type="button"
+          onClick={handleSignOut}
+          className="w-full inline-flex items-center justify-center gap-1.5 text-sm text-warm-gray hover:text-moss-green transition-colors"
+        >
+          <LogOut className="w-3.5 h-3.5" aria-hidden="true" />
+          Sign out instead
+        </button>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/auth/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/auth/ForgotPasswordPage.tsx
@@ -66,8 +66,8 @@ export default function ForgotPasswordPage() {
         {submitted ? (
           /* Success state */
           <div className="text-center space-y-4">
-            <CheckCircle className="w-14 h-14 text-moss-green mx-auto" aria-hidden="true" />
-            <h1 className="text-2xl font-bold text-moss-green font-heading">Check your inbox</h1>
+            <CheckCircle className="w-14 h-14 text-brand-ink mx-auto" aria-hidden="true" />
+            <h1 className="text-2xl font-bold text-brand-ink font-heading">Check your inbox</h1>
             <p className="text-sm text-warm-gray leading-relaxed">
               {serverMessage || 'If an account with that email address exists, we\'ve sent a password reset link. The link expires in 1 hour.'}
             </p>
@@ -76,7 +76,7 @@ export default function ForgotPasswordPage() {
             </p>
             <Link
               to="/auth/login"
-              className="inline-flex items-center gap-2 text-sm text-moss-green hover:text-moss-green/80 font-medium transition-colors"
+              className="inline-flex items-center gap-2 text-sm text-brand-ink hover:text-brand-ink/80 font-medium transition-colors"
             >
               <ArrowLeft className="w-4 h-4" aria-hidden="true" />
               Back to Sign In
@@ -87,9 +87,9 @@ export default function ForgotPasswordPage() {
           <>
             <div className="text-center">
               <div className="flex justify-center mb-3">
-                <Mail className="w-10 h-10 text-moss-green/70" aria-hidden="true" />
+                <Mail className="w-10 h-10 text-brand-ink/70" aria-hidden="true" />
               </div>
-              <h1 className="text-2xl font-bold text-moss-green font-heading">Forgot your password?</h1>
+              <h1 className="text-2xl font-bold text-brand-ink font-heading">Forgot your password?</h1>
               <p className="mt-2 text-sm text-warm-gray">
                 Enter your email address and we'll send you a link to reset your password.
               </p>
@@ -97,7 +97,7 @@ export default function ForgotPasswordPage() {
 
             <form onSubmit={handleSubmit} className="space-y-4" noValidate>
               <div>
-                <label htmlFor="email" className="block text-sm font-medium text-moss-green mb-1">
+                <label htmlFor="email" className="block text-sm font-medium text-brand-ink mb-1">
                   Email address
                 </label>
                 <input
@@ -110,7 +110,7 @@ export default function ForgotPasswordPage() {
                     setEmail(e.target.value);
                     setEmailError('');
                   }}
-                  className={`input-cozy w-full ${emailError ? 'border-red-400 focus:ring-red-400' : ''}`}
+                  className={`input-cozy w-full ${emailError ? 'border-danger/60 focus:ring-danger' : ''}`}
                   placeholder="your@email.com"
                   disabled={loading}
                   aria-required="true"
@@ -118,7 +118,7 @@ export default function ForgotPasswordPage() {
                   aria-describedby={emailError ? 'email-error' : undefined}
                 />
                 {emailError && (
-                  <p id="email-error" role="alert" className="mt-1 text-xs text-red-600">{emailError}</p>
+                  <p id="email-error" role="alert" className="mt-1 text-xs text-danger-ink">{emailError}</p>
                 )}
               </div>
 
@@ -144,7 +144,7 @@ export default function ForgotPasswordPage() {
             <div className="text-center">
               <Link
                 to="/auth/login"
-                className="inline-flex items-center gap-1.5 text-sm text-moss-green hover:text-moss-green/80 transition-colors"
+                className="inline-flex items-center gap-1.5 text-sm text-brand-ink hover:text-brand-ink/80 transition-colors"
               >
                 <ArrowLeft className="w-4 h-4" aria-hidden="true" />
                 Back to Sign In

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -108,7 +108,7 @@ export default function LoginPage() {
       <main id="main-content" className="glass-panel max-w-md w-full p-8 space-y-6">
         {/* Header */}
         <div className="text-center">
-          <h1 className="text-3xl font-bold text-moss-green font-heading">
+          <h1 className="text-3xl font-bold text-brand-ink font-heading">
             Welcome Back
           </h1>
           <p className="mt-2 text-sm text-warm-gray">
@@ -129,7 +129,7 @@ export default function LoginPage() {
           <div>
             <label
               htmlFor="email"
-              className="block text-sm font-medium text-moss-green mb-1"
+              className="block text-sm font-medium text-brand-ink mb-1"
             >
               Email
             </label>
@@ -160,7 +160,7 @@ export default function LoginPage() {
           <div>
             <label
               htmlFor="password"
-              className="block text-sm font-medium text-moss-green mb-1"
+              className="block text-sm font-medium text-brand-ink mb-1"
             >
               Password
             </label>
@@ -208,7 +208,7 @@ export default function LoginPage() {
 
             <Link
               to="/auth/forgot-password"
-              className="text-sm text-moss-green hover:text-moss-green/80 transition-colors"
+              className="text-sm text-brand-ink hover:text-brand-ink/80 transition-colors"
             >
               Forgot password?
             </Link>
@@ -257,7 +257,7 @@ export default function LoginPage() {
               Don't have an account?{' '}
               <Link
                 to="/auth/register"
-                className="text-moss-green hover:text-moss-green/80 font-medium transition-colors"
+                className="text-brand-ink hover:text-brand-ink/80 font-medium transition-colors"
               >
                 Create one
               </Link>

--- a/frontend/src/pages/auth/MFAVerifyPage.tsx
+++ b/frontend/src/pages/auth/MFAVerifyPage.tsx
@@ -134,7 +134,7 @@ export default function MFAVerifyPage() {
           <div className="flex justify-center mb-4">
             <div className="bg-moss-green/10 rounded-full p-3">
               <svg
-                className="w-8 h-8 text-moss-green"
+                className="w-8 h-8 text-brand-ink"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -148,7 +148,7 @@ export default function MFAVerifyPage() {
               </svg>
             </div>
           </div>
-          <h1 className="text-3xl font-bold text-moss-green font-heading">
+          <h1 className="text-3xl font-bold text-brand-ink font-heading">
             Two-Factor Authentication
           </h1>
           <p className="mt-2 text-sm text-warm-gray">
@@ -171,7 +171,7 @@ export default function MFAVerifyPage() {
             <div>
               <label
                 htmlFor="token"
-                className="block text-sm font-medium text-moss-green mb-1"
+                className="block text-sm font-medium text-brand-ink mb-1"
               >
                 Authentication Code
               </label>
@@ -240,7 +240,7 @@ export default function MFAVerifyPage() {
             <div>
               <label
                 htmlFor="backupCode"
-                className="block text-sm font-medium text-moss-green mb-1"
+                className="block text-sm font-medium text-brand-ink mb-1"
               >
                 Backup Code
               </label>
@@ -313,7 +313,7 @@ export default function MFAVerifyPage() {
         <div className="text-center">
           <button
             onClick={toggleInputMode}
-            className="text-sm text-moss-green hover:text-moss-green/80 transition-colors"
+            className="text-sm text-brand-ink hover:text-brand-ink/80 transition-colors"
             disabled={loading}
           >
             {useBackupCode
@@ -326,7 +326,7 @@ export default function MFAVerifyPage() {
         <div className="text-center pt-4 border-t border-warm-gray/20">
           <button
             onClick={() => navigate('/auth/login')}
-            className="text-sm text-warm-gray hover:text-moss-green transition-colors"
+            className="text-sm text-warm-gray hover:text-brand-ink transition-colors"
             disabled={loading}
           >
             Back to login

--- a/frontend/src/pages/auth/RegisterPage.tsx
+++ b/frontend/src/pages/auth/RegisterPage.tsx
@@ -136,10 +136,10 @@ export default function RegisterPage() {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-soft-cream via-parchment to-warm-amber/20 px-4">
         <div className="glass-panel max-w-md w-full p-8 space-y-4 text-center">
-          <div className="w-16 h-16 rounded-full bg-amber-100 flex items-center justify-center mx-auto">
+          <div className="w-16 h-16 rounded-full bg-warning/10 flex items-center justify-center mx-auto">
             <span className="text-3xl">&#9203;</span>
           </div>
-          <h1 className="text-2xl font-bold text-moss-green font-heading">Registration Submitted</h1>
+          <h1 className="text-2xl font-bold text-brand-ink font-heading">Registration Submitted</h1>
           <p className="text-warm-gray text-sm">
             Your account has been created and is <strong>pending admin approval</strong>. You will be able to log in once an administrator approves your account.
           </p>
@@ -156,7 +156,7 @@ export default function RegisterPage() {
       <div className="glass-panel max-w-md w-full p-8 space-y-6">
         {/* Header */}
         <div className="text-center">
-          <h1 className="text-3xl font-bold text-moss-green font-heading">
+          <h1 className="text-3xl font-bold text-brand-ink font-heading">
             Create Account
           </h1>
           <p className="mt-2 text-sm text-warm-gray">
@@ -177,7 +177,7 @@ export default function RegisterPage() {
           <div>
             <label
               htmlFor="displayName"
-              className="block text-sm font-medium text-moss-green mb-1"
+              className="block text-sm font-medium text-brand-ink mb-1"
             >
               Display Name
             </label>
@@ -213,7 +213,7 @@ export default function RegisterPage() {
           <div>
             <label
               htmlFor="email"
-              className="block text-sm font-medium text-moss-green mb-1"
+              className="block text-sm font-medium text-brand-ink mb-1"
             >
               Email
             </label>
@@ -244,7 +244,7 @@ export default function RegisterPage() {
           <div>
             <label
               htmlFor="password"
-              className="block text-sm font-medium text-moss-green mb-1"
+              className="block text-sm font-medium text-brand-ink mb-1"
             >
               Password
             </label>
@@ -287,10 +287,10 @@ export default function RegisterPage() {
                   <span
                     className={`text-xs font-medium ${
                       passwordStrength.color === 'green'
-                        ? 'text-green-600'
+                        ? 'text-success-ink'
                         : passwordStrength.color === 'yellow'
-                        ? 'text-yellow-600'
-                        : 'text-red-600'
+                        ? 'text-warning-ink'
+                        : 'text-danger-ink'
                     }`}
                   >
                     {passwordStrength.label}
@@ -300,10 +300,10 @@ export default function RegisterPage() {
                   <div
                     className={`h-1.5 rounded-full transition-all ${
                       passwordStrength.color === 'green'
-                        ? 'bg-green-600'
+                        ? 'bg-success'
                         : passwordStrength.color === 'yellow'
-                        ? 'bg-yellow-600'
-                        : 'bg-red-600'
+                        ? 'bg-warning'
+                        : 'bg-danger'
                     }`}
                     style={{ width: `${(passwordStrength.score / 10) * 100}%` }}
                   ></div>
@@ -316,7 +316,7 @@ export default function RegisterPage() {
           <div>
             <label
               htmlFor="confirmPassword"
-              className="block text-sm font-medium text-moss-green mb-1"
+              className="block text-sm font-medium text-brand-ink mb-1"
             >
               Confirm Password
             </label>
@@ -389,7 +389,7 @@ export default function RegisterPage() {
             Already have an account?{' '}
             <Link
               to="/auth/login"
-              className="text-moss-green hover:text-moss-green/80 font-medium transition-colors"
+              className="text-brand-ink hover:text-brand-ink/80 font-medium transition-colors"
             >
               Sign in
             </Link>

--- a/frontend/src/pages/auth/ResetPasswordPage.tsx
+++ b/frontend/src/pages/auth/ResetPasswordPage.tsx
@@ -90,8 +90,8 @@ export default function ResetPasswordPage({ invite = false }: ResetPasswordPageP
         {success ? (
           /* Success state */
           <div className="text-center space-y-4">
-            <CheckCircle className="w-14 h-14 text-moss-green mx-auto" aria-hidden="true" />
-            <h1 className="text-2xl font-bold text-moss-green font-heading">
+            <CheckCircle className="w-14 h-14 text-brand-ink mx-auto" aria-hidden="true" />
+            <h1 className="text-2xl font-bold text-brand-ink font-heading">
               {invite ? "You're all set!" : 'Password updated!'}
             </h1>
             <p className="text-sm text-warm-gray">
@@ -106,13 +106,13 @@ export default function ResetPasswordPage({ invite = false }: ResetPasswordPageP
         ) : !token ? (
           /* Invalid / missing token */
           <div className="text-center space-y-4">
-            <AlertCircle className="w-14 h-14 text-red-500 mx-auto" aria-hidden="true" />
-            <h1 className="text-2xl font-bold text-moss-green font-heading">Invalid link</h1>
+            <AlertCircle className="w-14 h-14 text-danger-ink mx-auto" aria-hidden="true" />
+            <h1 className="text-2xl font-bold text-brand-ink font-heading">Invalid link</h1>
             <p className="text-sm text-warm-gray">{error}</p>
             {!invite && (
               <Link
                 to="/auth/forgot-password"
-                className="inline-flex items-center gap-1.5 text-sm text-moss-green hover:text-moss-green/80 font-medium transition-colors"
+                className="inline-flex items-center gap-1.5 text-sm text-brand-ink hover:text-brand-ink/80 font-medium transition-colors"
               >
                 Request a new reset link
               </Link>
@@ -123,9 +123,9 @@ export default function ResetPasswordPage({ invite = false }: ResetPasswordPageP
           <>
             <div className="text-center">
               <div className="flex justify-center mb-3">
-                <KeyRound className="w-10 h-10 text-moss-green/70" aria-hidden="true" />
+                <KeyRound className="w-10 h-10 text-brand-ink/70" aria-hidden="true" />
               </div>
-              <h1 className="text-2xl font-bold text-moss-green font-heading">
+              <h1 className="text-2xl font-bold text-brand-ink font-heading">
                 {invite ? 'Welcome to CozyVTT' : 'Set new password'}
               </h1>
               <p className="mt-2 text-sm text-warm-gray">
@@ -136,16 +136,16 @@ export default function ResetPasswordPage({ invite = false }: ResetPasswordPageP
             </div>
 
             {error && (
-              <div role="alert" className="flex items-start gap-2 bg-red-50 border border-red-200 rounded-lg p-3">
-                <AlertCircle className="w-4 h-4 text-red-500 mt-0.5 flex-shrink-0" />
-                <p className="text-sm text-red-700">{error}</p>
+              <div role="alert" className="flex items-start gap-2 bg-danger/10 border border-danger/30 rounded-lg p-3">
+                <AlertCircle className="w-4 h-4 text-danger-ink mt-0.5 flex-shrink-0" />
+                <p className="text-sm text-danger-ink">{error}</p>
               </div>
             )}
 
             <form onSubmit={handleSubmit} className="space-y-4" noValidate>
               {/* New password */}
               <div>
-                <label htmlFor="password" className="block text-sm font-medium text-moss-green mb-1">
+                <label htmlFor="password" className="block text-sm font-medium text-brand-ink mb-1">
                   New password
                 </label>
                 <input
@@ -158,14 +158,14 @@ export default function ResetPasswordPage({ invite = false }: ResetPasswordPageP
                     setPassword(e.target.value);
                     setFieldErrors((prev) => ({ ...prev, password: undefined }));
                   }}
-                  className={`input-cozy w-full ${fieldErrors.password ? 'border-red-400 focus:ring-red-400' : ''}`}
+                  className={`input-cozy w-full ${fieldErrors.password ? 'border-danger/60 focus:ring-danger' : ''}`}
                   disabled={loading}
                   aria-required="true"
                   aria-invalid={!!fieldErrors.password}
                   aria-describedby="password-requirements"
                 />
                 {fieldErrors.password && (
-                  <p role="alert" className="mt-1 text-xs text-red-600">{fieldErrors.password}</p>
+                  <p role="alert" className="mt-1 text-xs text-danger-ink">{fieldErrors.password}</p>
                 )}
               </div>
 
@@ -173,7 +173,7 @@ export default function ResetPasswordPage({ invite = false }: ResetPasswordPageP
               {password.length > 0 && (
                 <ul id="password-requirements" className="space-y-1" aria-label="Password requirements">
                   {PASSWORD_REQUIREMENTS.map((req, i) => (
-                    <li key={i} className={`flex items-center gap-2 text-xs ${requirementsMet[i] ? 'text-moss-green' : 'text-warm-gray'}`}>
+                    <li key={i} className={`flex items-center gap-2 text-xs ${requirementsMet[i] ? 'text-brand-ink' : 'text-warm-gray'}`}>
                       <span aria-hidden="true">{requirementsMet[i] ? '✓' : '○'}</span>
                       {req.label}
                     </li>
@@ -183,7 +183,7 @@ export default function ResetPasswordPage({ invite = false }: ResetPasswordPageP
 
               {/* Confirm password */}
               <div>
-                <label htmlFor="confirm-password" className="block text-sm font-medium text-moss-green mb-1">
+                <label htmlFor="confirm-password" className="block text-sm font-medium text-brand-ink mb-1">
                   Confirm new password
                 </label>
                 <input
@@ -195,14 +195,14 @@ export default function ResetPasswordPage({ invite = false }: ResetPasswordPageP
                     setConfirmPassword(e.target.value);
                     setFieldErrors((prev) => ({ ...prev, confirm: undefined }));
                   }}
-                  className={`input-cozy w-full ${fieldErrors.confirm ? 'border-red-400 focus:ring-red-400' : ''}`}
+                  className={`input-cozy w-full ${fieldErrors.confirm ? 'border-danger/60 focus:ring-danger' : ''}`}
                   disabled={loading}
                   aria-required="true"
                   aria-invalid={!!fieldErrors.confirm}
                   aria-describedby={fieldErrors.confirm ? 'confirm-error' : undefined}
                 />
                 {fieldErrors.confirm && (
-                  <p id="confirm-error" role="alert" className="mt-1 text-xs text-red-600">{fieldErrors.confirm}</p>
+                  <p id="confirm-error" role="alert" className="mt-1 text-xs text-danger-ink">{fieldErrors.confirm}</p>
                 )}
               </div>
 
@@ -228,7 +228,7 @@ export default function ResetPasswordPage({ invite = false }: ResetPasswordPageP
             <div className="text-center">
               <Link
                 to="/auth/login"
-                className="inline-flex items-center gap-1.5 text-sm text-moss-green hover:text-moss-green/80 transition-colors"
+                className="inline-flex items-center gap-1.5 text-sm text-brand-ink hover:text-brand-ink/80 transition-colors"
               >
                 <ArrowLeft className="w-4 h-4" aria-hidden="true" />
                 Back to Sign In

--- a/frontend/src/pages/auth/ResetPasswordPage.tsx
+++ b/frontend/src/pages/auth/ResetPasswordPage.tsx
@@ -2,6 +2,10 @@
 // Reset Password Page
 // Allows users to set a new password via a valid reset token
 // Accessed via /reset-password?token=<uuid>
+//
+// Also serves invitations at /accept-invite?token=<uuid> (`invite` prop). Same
+// token, same endpoint — an invited account has no password yet, so "set one"
+// and "reset yours" are the same operation with different wording.
 // ============================================
 
 import { useState, FormEvent, useEffect } from 'react';
@@ -9,16 +13,14 @@ import { Link, useSearchParams } from 'react-router-dom';
 import { KeyRound, ArrowLeft, CheckCircle, AlertCircle } from 'lucide-react';
 import authService from '@/services/auth.service';
 import Button from '@/components/ui/Button';
+import { PASSWORD_REQUIREMENTS } from '@/utils/validation';
 
-const PASSWORD_REQUIREMENTS = [
-  { test: (p: string) => p.length >= 8,           label: 'At least 8 characters' },
-  { test: (p: string) => /[A-Z]/.test(p),         label: 'One uppercase letter' },
-  { test: (p: string) => /[a-z]/.test(p),         label: 'One lowercase letter' },
-  { test: (p: string) => /[0-9]/.test(p),         label: 'One number' },
-  { test: (p: string) => /[^A-Za-z0-9]/.test(p), label: 'One special character' },
-];
+interface ResetPasswordPageProps {
+  /** Render invitation copy instead of password-reset copy (route: /accept-invite) */
+  invite?: boolean;
+}
 
-export default function ResetPasswordPage() {
+export default function ResetPasswordPage({ invite = false }: ResetPasswordPageProps) {
   const [searchParams] = useSearchParams();
   const token = searchParams.get('token');
 
@@ -31,9 +33,13 @@ export default function ResetPasswordPage() {
 
   useEffect(() => {
     if (!token) {
-      setError('This password reset link is invalid. Please request a new one.');
+      setError(
+        invite
+          ? 'This invitation link is invalid. Ask your administrator to send a new one.'
+          : 'This password reset link is invalid. Please request a new one.'
+      );
     }
-  }, [token]);
+  }, [token, invite]);
 
   const requirementsMet = PASSWORD_REQUIREMENTS.map((r) => r.test(password));
   const allRequirementsMet = requirementsMet.every(Boolean);
@@ -66,7 +72,12 @@ export default function ResetPasswordPage() {
       setSuccess(true);
     } catch (err: unknown) {
       const msg = (err as { response?: { data?: { message?: string } } }).response?.data?.message;
-      setError(msg || 'Failed to reset password. This link may have expired.');
+      setError(
+        msg ||
+          (invite
+            ? 'Failed to set your password. This invitation may have expired.'
+            : 'Failed to reset password. This link may have expired.')
+      );
     } finally {
       setLoading(false);
     }
@@ -80,9 +91,13 @@ export default function ResetPasswordPage() {
           /* Success state */
           <div className="text-center space-y-4">
             <CheckCircle className="w-14 h-14 text-moss-green mx-auto" aria-hidden="true" />
-            <h1 className="text-2xl font-bold text-moss-green font-heading">Password updated!</h1>
+            <h1 className="text-2xl font-bold text-moss-green font-heading">
+              {invite ? "You're all set!" : 'Password updated!'}
+            </h1>
             <p className="text-sm text-warm-gray">
-              Your password has been reset successfully. You can now sign in with your new password.
+              {invite
+                ? 'Your account is ready. Sign in with the password you just chose.'
+                : 'Your password has been reset successfully. You can now sign in with your new password.'}
             </p>
             <Link to="/auth/login" className="btn-primary inline-block px-6 py-2">
               Sign In
@@ -94,12 +109,14 @@ export default function ResetPasswordPage() {
             <AlertCircle className="w-14 h-14 text-red-500 mx-auto" aria-hidden="true" />
             <h1 className="text-2xl font-bold text-moss-green font-heading">Invalid link</h1>
             <p className="text-sm text-warm-gray">{error}</p>
-            <Link
-              to="/auth/forgot-password"
-              className="inline-flex items-center gap-1.5 text-sm text-moss-green hover:text-moss-green/80 font-medium transition-colors"
-            >
-              Request a new reset link
-            </Link>
+            {!invite && (
+              <Link
+                to="/auth/forgot-password"
+                className="inline-flex items-center gap-1.5 text-sm text-moss-green hover:text-moss-green/80 font-medium transition-colors"
+              >
+                Request a new reset link
+              </Link>
+            )}
           </div>
         ) : (
           /* Form state */
@@ -108,9 +125,13 @@ export default function ResetPasswordPage() {
               <div className="flex justify-center mb-3">
                 <KeyRound className="w-10 h-10 text-moss-green/70" aria-hidden="true" />
               </div>
-              <h1 className="text-2xl font-bold text-moss-green font-heading">Set new password</h1>
+              <h1 className="text-2xl font-bold text-moss-green font-heading">
+                {invite ? 'Welcome to CozyVTT' : 'Set new password'}
+              </h1>
               <p className="mt-2 text-sm text-warm-gray">
-                Choose a strong password for your account.
+                {invite
+                  ? 'Choose a password to finish setting up your account.'
+                  : 'Choose a strong password for your account.'}
               </p>
             </div>
 
@@ -199,7 +220,7 @@ export default function ResetPasswordPage() {
                     Updating...
                   </span>
                 ) : (
-                  'Set New Password'
+                  invite ? 'Create My Account' : 'Set New Password'
                 )}
               </Button>
             </form>

--- a/frontend/src/services/admin.service.ts
+++ b/frontend/src/services/admin.service.ts
@@ -60,9 +60,26 @@ class AdminService {
     email: string;
     displayName?: string;
     platformRole?: string;
-  }): Promise<{ user: User; temporaryPassword: string }> {
+  }): Promise<{ user: User; emailSent: boolean; temporaryPassword?: string }> {
     const result = await api.createAdminUser(data);
-    return { user: result.user, temporaryPassword: result.temporaryPassword };
+    return {
+      user: result.user,
+      emailSent: result.emailSent,
+      temporaryPassword: result.temporaryPassword,
+    };
+  }
+
+  async inviteUser(data: {
+    email: string;
+    displayName?: string;
+    platformRole?: string;
+  }): Promise<{ user: User; expiresInDays: number }> {
+    const result = await api.inviteAdminUser(data);
+    return { user: result.user, expiresInDays: result.expiresInDays };
+  }
+
+  async resendInvite(userId: string): Promise<{ message: string; expiresInDays: number }> {
+    return await api.resendAdminUserInvite(userId);
   }
 
   async resetMfa(userId: string): Promise<void> {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -108,7 +108,16 @@ class ApiClient {
 
           // Forbidden
           if (status === 403) {
-            console.error('Permission denied:', data.message);
+            // The account must replace an admin-issued password before it can
+            // do anything else. Covers tabs left open when the flag was set.
+            const code = (data as { code?: string })?.code;
+            if (code === 'PASSWORD_CHANGE_REQUIRED') {
+              if (window.location.pathname !== '/auth/change-password') {
+                window.location.href = '/auth/change-password';
+              }
+            } else {
+              console.error('Permission denied:', data.message);
+            }
           }
 
           // Rate limited
@@ -318,12 +327,33 @@ class ApiClient {
     return response.data;
   }
 
+  /**
+   * Create a user with a temporary password. `temporaryPassword` is only
+   * returned when the welcome email could not be sent (no SMTP, or delivery
+   * failed) — otherwise the user has it and the admin does not need it.
+   */
   async createAdminUser(data: {
     email: string;
     displayName?: string;
     platformRole?: string;
-  }): Promise<{ message: string; user: User; temporaryPassword: string }> {
+  }): Promise<{ message: string; user: User; emailSent: boolean; temporaryPassword?: string }> {
     const response = await this.client.post('/api/admin/users', data);
+    return response.data;
+  }
+
+  /** Invite a user by email — no password is created or returned. */
+  async inviteAdminUser(data: {
+    email: string;
+    displayName?: string;
+    platformRole?: string;
+  }): Promise<{ message: string; user: User; expiresInDays: number }> {
+    const response = await this.client.post('/api/admin/users/invite', data);
+    return response.data;
+  }
+
+  /** Issue a fresh invitation link, invalidating any outstanding one. */
+  async resendAdminUserInvite(userId: string): Promise<{ message: string; expiresInDays: number }> {
+    const response = await this.client.post(`/api/admin/users/${userId}/resend-invite`);
     return response.data;
   }
 

--- a/frontend/src/themes.ts
+++ b/frontend/src/themes.ts
@@ -5,9 +5,17 @@
  * variable consumed by Tailwind. Tailwind composes them with alpha via
  * rgb(var(--color-x) / <alpha-value>).
  *
- * Readability contract: every theme guarantees WCAG AA contrast (≥4.5:1)
- * between text colors and their expected backgrounds.
+ * Readability contract: every theme meets WCAG AA contrast (≥4.5:1) between
+ * text colors and the backgrounds they are rendered on. This is enforced, not
+ * assumed — see utils/__tests__/themes.contrast.test.ts, which fails the build
+ * on any violation.
+ *
+ * Colors that exist to be *fills* (accent, spirit, danger, and the state hues)
+ * get a derived `-ink` variant for use as text; see deriveReadableTokens.
+ * Authored values that already pass are never modified.
  */
+
+import { ensureReadableChannels, ensureReadableOnAll, readableTextOn } from './utils/color';
 
 export interface ThemeColors {
   brand: string;
@@ -524,6 +532,53 @@ export function rgbChannelsToHex(channels: string): string {
   return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
 }
 
+/**
+ * Canonical hues for states the palettes don't define. Each is adapted per
+ * theme (see deriveReadableTokens) so a dark theme gets a lighter green rather
+ * than one that disappears into the background.
+ */
+export const STATE_HUES = {
+  success: '34 139 68',
+  warning: '191 129 20',
+  info: '37 99 190',
+} as const;
+
+/**
+ * Tokens computed from a theme rather than authored in it.
+ *
+ * Two kinds live here:
+ *   - `-ink` variants: readable text versions of colors that exist to be
+ *     *fills* (accent, spirit, danger, and the state hues). The fill keeps its
+ *     designed color; only text uses the ink.
+ *   - a clamped `inkMuted`: authored values that already pass are returned
+ *     unchanged, so this only moves the themes whose muted text is genuinely
+ *     too faint.
+ */
+export function deriveReadableTokens(colors: ThemeColors): Record<string, string> {
+  const onPage = [colors.bgBase, colors.bgSurface];
+  const onPaper = [colors.paper];
+  const everywhere = [...onPage, ...onPaper];
+
+  return {
+    '--color-ink-muted': ensureReadableOnAll(colors.inkMuted, everywhere),
+    // Label on an accent-filled button. Authored values that already contrast
+    // are kept; the rest are nudged until the label is legible.
+    '--color-accent-text': ensureReadableChannels(colors.accentText, colors.accent),
+    // brand is a fill in ~290 places (buttons, borders) AND text in ~470.
+    // The fill keeps the authored color; text uses this readable shade of it.
+    '--color-brand-ink': ensureReadableOnAll(colors.brand, everywhere),
+    '--color-accent-ink': ensureReadableOnAll(colors.accent, everywhere),
+    '--color-spirit-ink': ensureReadableOnAll(colors.spirit, everywhere),
+    '--color-danger-ink': ensureReadableOnAll(colors.danger, everywhere),
+    '--color-success': STATE_HUES.success,
+    '--color-success-ink': ensureReadableOnAll(STATE_HUES.success, everywhere),
+    '--color-warning': STATE_HUES.warning,
+    '--color-warning-ink': ensureReadableOnAll(STATE_HUES.warning, everywhere),
+    '--color-info': STATE_HUES.info,
+    '--color-info-ink': ensureReadableOnAll(STATE_HUES.info, everywhere),
+  };
+}
+
 export function applyThemeColors(colors: ThemeColors): void {
   const root = document.documentElement;
   root.style.setProperty('--color-brand', colors.brand);
@@ -541,6 +596,13 @@ export function applyThemeColors(colors: ThemeColors): void {
   root.style.setProperty('--color-paper', colors.paper);
   root.style.setProperty('--color-danger', colors.danger);
   root.style.setProperty('--color-spirit', colors.spirit);
+
+  // Readable text variants + state colors, computed from the above.
+  // Set last: --color-ink-muted is intentionally overwritten with its clamped
+  // value when the authored one is too faint to read.
+  for (const [name, value] of Object.entries(deriveReadableTokens(colors))) {
+    root.style.setProperty(name, value);
+  }
 }
 
 export function applyFont(font: FontOption): void {
@@ -581,25 +643,34 @@ export function buildCustomThemeColors(customColors: {
     return `${Math.min(255, r + amount)} ${Math.min(255, g + amount)} ${Math.min(255, b + amount)}`;
   };
 
-  // Compute accent text: needs to contrast with the accent background
-  const accentRgb = customColors.accent.split(' ').map(Number);
-  const accentIsLight = (accentRgb[0] + accentRgb[1] + accentRgb[2]) / 3 > 128;
-  const accentTextColor = accentIsLight ? darken(customColors.accent, 120) : lighten(customColors.accent, 120);
+  const surface = isLight ? darken(customColors.background, 12) : lighten(customColors.background, 8);
+  const paper = isLight ? '254 254 254' : lighten(customColors.background, 20);
+  const readableOn = [customColors.background, surface, paper];
 
   return {
-    brand: customColors.primary,
+    // Brand and ink are the user's choices, nudged only if they would be
+    // unreadable on their own background — text the user cannot read is never
+    // what they meant to pick
+    brand: ensureReadableOnAll(customColors.primary, readableOn),
     brandDark: isLight ? darken(customColors.primary, 30) : lighten(customColors.primary, 30),
     accent: customColors.accent,
     accentHover: lighten(customColors.accent, 20),
-    accentText: accentTextColor,
+    // Label on an accent-filled button
+    accentText: readableTextOn(customColors.accent),
     bgBase: customColors.background,
-    bgSurface: isLight ? darken(customColors.background, 12) : lighten(customColors.background, 8),
+    bgSurface: surface,
     bgSurfaceLight: isLight ? darken(customColors.background, 5) : lighten(customColors.background, 12),
     bgSurfaceDark: isLight ? darken(customColors.background, 25) : darken(customColors.background, 6),
-    ink: customColors.text,
-    inkSecondary: isLight ? lighten(customColors.text, 60) : darken(customColors.text, 60),
-    inkMuted: isLight ? lighten(customColors.text, 90) : darken(customColors.text, 90),
-    paper: isLight ? '254 254 254' : lighten(customColors.background, 20),
+    ink: ensureReadableOnAll(customColors.text, readableOn),
+    inkSecondary: ensureReadableOnAll(
+      isLight ? lighten(customColors.text, 60) : darken(customColors.text, 60),
+      readableOn
+    ),
+    inkMuted: ensureReadableOnAll(
+      isLight ? lighten(customColors.text, 90) : darken(customColors.text, 90),
+      readableOn
+    ),
+    paper,
     danger: customColors.danger || '192 57 43',
     spirit: customColors.spirit || '147 112 219',
   };

--- a/frontend/src/utils/__tests__/themeTokens.test.ts
+++ b/frontend/src/utils/__tests__/themeTokens.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Theme Token Guard
+ *
+ * Raw Tailwind palette colors (bg-red-50, text-stone-500, …) do not follow the
+ * theme: an error box built from them stays pale pink on a dark theme, and grey
+ * text keeps its light-mode shade on a dark panel. Every themed surface must use
+ * the semantic tokens instead — see the alert and badge classes in index.css,
+ * and the token list in tailwind.config.js.
+ *
+ * Two areas are deliberately exempt because they are fixed-surface designs
+ * rather than themed UI, and are listed explicitly so the exemption stays
+ * visible and reviewable.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Fixed-surface designs, exempt by intent:
+ *  - character sheets render as light "paper" cards, the way the physical
+ *    sheets look, and keep their own palette (including the Call of Cthulhu
+ *    sepia set, which tailwind.config.js documents as static)
+ *  - the DM map overlays are deliberately dark panels floating over the map
+ */
+const EXEMPT = [
+  '/src/components/character-sheets/',
+  '/src/components/campaign/DmWallControls.tsx',
+  '/src/components/campaign/DmLightControls.tsx',
+  '/src/components/campaign/DmFogControls.tsx',
+  '/src/components/campaign/DmToolPanelContainer.tsx',
+];
+
+/** Palette families that have a semantic token to use instead. */
+const RAW_COLOR =
+  /\b(?:text|bg|border|ring|divide|placeholder|from|via|to)-(?:red|rose|green|emerald|amber|yellow|orange|blue|indigo|sky|purple|violet|stone|gray|slate|zinc|neutral)-\d{2,3}\b/g;
+
+// Vite inlines every component's source at build time, so the check needs no
+// filesystem access and runs in the same environment as the rest of the suite.
+const SOURCES = import.meta.glob('/src/**/*.tsx', { query: '?raw', import: 'default', eager: true }) as Record<string, string>;
+
+describe('themed surfaces use semantic tokens', () => {
+  const offenders = Object.entries(SOURCES)
+    .filter(([path]) => !EXEMPT.some((exempt) => path.startsWith(exempt) || path === exempt))
+    .map(([path, source]) => ({
+      file: path,
+      matches: [...new Set(source.match(RAW_COLOR) ?? [])],
+    }))
+    .filter((entry) => entry.matches.length > 0);
+
+  it('scans the component tree', () => {
+    expect(Object.keys(SOURCES).length).toBeGreaterThan(50);
+  });
+
+  it('finds no raw Tailwind palette colors outside the exempt fixed-surface areas', () => {
+    const report = offenders.map((o) => `  ${o.file}: ${o.matches.join(', ')}`).join('\n');
+    expect(
+      offenders.map((o) => o.file),
+      offenders.length
+        ? 'Raw palette colors found on themed surfaces — use the semantic tokens ' +
+            '(danger / success / warning / info / spirit and the ink scale), or the ' +
+            `alert classes in index.css:\n${report}`
+        : ''
+    ).toHaveLength(0);
+  });
+
+  it('keeps the exemption list small and intentional', () => {
+    // A growing exemption list means the rule is being worked around rather
+    // than followed; make that visible in review.
+    expect(EXEMPT.length).toBeLessThanOrEqual(6);
+  });
+});

--- a/frontend/src/utils/__tests__/themes.contrast.test.ts
+++ b/frontend/src/utils/__tests__/themes.contrast.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Theme Contrast — the readability contract, enforced
+ *
+ * themes.ts promises WCAG AA (≥4.5:1) between text colors and the backgrounds
+ * they render on. Before this test existed, all 16 preset themes broke that
+ * promise somewhere — muted text sat at 3.3–4.4:1 in 13 of them, and accent
+ * text bottomed out at 1.84:1 in Northern Frost.
+ *
+ * The pairs below are the ones the UI genuinely renders, with the class usage
+ * counts that justify each entry. If a token stops being used as text, remove
+ * its pair rather than lowering the bar.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PRESET_THEMES, deriveReadableTokens, type ThemeColors } from '@/themes';
+import { contrastRatioChannels, AA_TEXT, AA_LARGE } from '../color';
+
+/** Backgrounds text is rendered on, by the token that provides them. */
+const BACKGROUNDS = ['bgBase', 'bgSurface', 'paper'] as const;
+type BackgroundToken = (typeof BACKGROUNDS)[number];
+
+interface TextToken {
+  /** Where the value comes from: an authored theme color or a derived token */
+  resolve: (colors: ThemeColors, derived: Record<string, string>) => string;
+  label: string;
+  /** Which backgrounds this text actually appears on */
+  on: BackgroundToken[];
+  threshold: number;
+}
+
+const TEXT_TOKENS: TextToken[] = [
+  // text-charcoal / text-ink — 92 uses
+  { label: 'ink', on: [...BACKGROUNDS], threshold: AA_TEXT, resolve: (c) => c.ink },
+  // text-warm-gray / text-ink-secondary — 321 uses
+  { label: 'ink-secondary', on: [...BACKGROUNDS], threshold: AA_TEXT, resolve: (c) => c.inkSecondary },
+  // text-stone-gray / text-ink-muted — 597 uses (the most common text color in the app)
+  { label: 'ink-muted (derived)', on: [...BACKGROUNDS], threshold: AA_TEXT,
+    resolve: (_c, d) => d['--color-ink-muted'] },
+  // text-brand-ink — 471 uses (brand is also a fill in ~290 places, which keeps
+  // the authored color; only the text variant is derived)
+  { label: 'brand-ink (derived)', on: [...BACKGROUNDS], threshold: AA_TEXT,
+    resolve: (_c, d) => d['--color-brand-ink'] },
+  // text-warm-amber / text-accent — 74 uses, now routed through accent-ink
+  { label: 'accent-ink (derived)', on: [...BACKGROUNDS], threshold: AA_TEXT,
+    resolve: (_c, d) => d['--color-accent-ink'] },
+  // text-spirit / text-spirit-purple — 98 uses
+  { label: 'spirit-ink (derived)', on: [...BACKGROUNDS], threshold: AA_TEXT,
+    resolve: (_c, d) => d['--color-spirit-ink'] },
+  // text-spirit-red / text-danger and .alert-danger
+  { label: 'danger-ink (derived)', on: [...BACKGROUNDS], threshold: AA_TEXT,
+    resolve: (_c, d) => d['--color-danger-ink'] },
+  // .alert-success / .badge-success
+  { label: 'success-ink (derived)', on: [...BACKGROUNDS], threshold: AA_TEXT,
+    resolve: (_c, d) => d['--color-success-ink'] },
+  // .alert-warning / .badge-warning
+  { label: 'warning-ink (derived)', on: [...BACKGROUNDS], threshold: AA_TEXT,
+    resolve: (_c, d) => d['--color-warning-ink'] },
+  // .alert-info
+  { label: 'info-ink (derived)', on: [...BACKGROUNDS], threshold: AA_TEXT,
+    resolve: (_c, d) => d['--color-info-ink'] },
+];
+
+describe('preset theme contrast', () => {
+  it('ships the themes the picker expects', () => {
+    expect(PRESET_THEMES.length).toBeGreaterThanOrEqual(16);
+  });
+
+  describe.each(PRESET_THEMES.map((t) => [t.name, t] as const))('%s', (_name, theme) => {
+    const derived = deriveReadableTokens(theme.colors);
+
+    it.each(
+      TEXT_TOKENS.flatMap((token) =>
+        token.on.map((bg) => [token.label, bg, token, bg] as const)
+      )
+    )('%s on %s meets AA', (_l, _b, token, bg) => {
+      const fg = token.resolve(theme.colors, derived);
+      const ratio = contrastRatioChannels(fg, theme.colors[bg]);
+      expect(
+        ratio,
+        `${theme.name}: ${token.label} (${fg}) on ${bg} (${theme.colors[bg]}) = ${ratio.toFixed(2)}:1`
+      ).toBeGreaterThanOrEqual(token.threshold);
+    });
+
+    // Button labels sit on the accent fill, not on a page background
+    it('accent button label meets AA against the accent fill', () => {
+      const accentText = derived['--color-accent-text'];
+      const ratio = contrastRatioChannels(accentText, theme.colors.accent);
+      expect(
+        ratio,
+        `${theme.name}: accentText (${accentText}) on accent (${theme.colors.accent}) = ${ratio.toFixed(2)}:1`
+      ).toBeGreaterThanOrEqual(AA_TEXT);
+    });
+  });
+});
+
+describe('derived tokens never weaken an authored color', () => {
+  it.each(PRESET_THEMES.map((t) => [t.name, t] as const))('%s', (_name, theme) => {
+    const derived = deriveReadableTokens(theme.colors);
+    // inkMuted is clamped, so it may change — but only ever to improve contrast
+    const before = contrastRatioChannels(theme.colors.inkMuted, theme.colors.bgBase);
+    const after = contrastRatioChannels(derived['--color-ink-muted'], theme.colors.bgBase);
+    expect(after).toBeGreaterThanOrEqual(Math.min(before, AA_LARGE));
+  });
+});

--- a/frontend/src/utils/color.ts
+++ b/frontend/src/utils/color.ts
@@ -1,0 +1,196 @@
+// ============================================
+// Color / Contrast Utilities
+//
+// One implementation of WCAG contrast, shared by everything that needs it:
+//   - themes.ts        derives readable text variants when a theme is applied
+//   - themes.ts        builds custom themes from an admin's chosen colors
+//   - ThemePicker      warns when a custom pairing is unreadable
+//   - themes.contrast  test that fails the build if a preset theme regresses
+//
+// Colors use the same "R G B" channel string the theme variables do
+// (e.g. "74 93 78"), so values move between CSS, themes.ts and here unchanged.
+// ============================================
+
+export type Rgb = [number, number, number];
+
+/** WCAG AA minimum for body text. */
+export const AA_TEXT = 4.5;
+/** WCAG AA minimum for large text and non-text UI (borders, icons). */
+export const AA_LARGE = 3;
+
+/** Parse a `"74 93 78"` channel string. Tolerates extra whitespace. */
+export function parseRgb(channels: string): Rgb {
+  const parts = channels.trim().split(/\s+/).map(Number);
+  if (parts.length !== 3 || parts.some((n) => !Number.isFinite(n))) {
+    // Fall back to mid-grey rather than throwing — a malformed custom color
+    // should never take the whole app down
+    return [128, 128, 128];
+  }
+  return [clampChannel(parts[0]), clampChannel(parts[1]), clampChannel(parts[2])];
+}
+
+/** Format an Rgb tuple back into the `"74 93 78"` channel string. */
+export function toChannels(rgb: Rgb): string {
+  return rgb.map((c) => Math.round(clampChannel(c))).join(' ');
+}
+
+function clampChannel(value: number): number {
+  return Math.min(255, Math.max(0, value));
+}
+
+/** WCAG 2.1 relative luminance. */
+export function relativeLuminance(rgb: Rgb): number {
+  const [r, g, b] = rgb.map((c) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** WCAG 2.1 contrast ratio, 1 (identical) to 21 (black on white). */
+export function contrastRatio(a: Rgb, b: Rgb): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const lighter = Math.max(la, lb);
+  const darker = Math.min(la, lb);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** Convenience wrapper for the channel-string form used by themes. */
+export function contrastRatioChannels(a: string, b: string): number {
+  return contrastRatio(parseRgb(a), parseRgb(b));
+}
+
+/**
+ * Adjust `foreground` until it reaches `target` contrast against `background`,
+ * keeping its hue.
+ *
+ * Moves away from the background's lightness — darkening a color on a light
+ * background, lightening it on a dark one — so an accent stays recognisably
+ * itself while becoming readable as text. Returns the input unchanged when it
+ * already passes, so authored colors that are fine are never touched.
+ */
+export function ensureReadable(
+  foreground: Rgb,
+  background: Rgb,
+  target: number = AA_TEXT
+): Rgb {
+  if (contrastRatio(foreground, background) >= target) {
+    return foreground;
+  }
+
+  // Darken against a light background, lighten against a dark one
+  const towardsBlack = relativeLuminance(background) > 0.18;
+  const [h, s] = rgbToHsl(foreground);
+  const startL = rgbToHsl(foreground)[2];
+
+  // Walk lightness in 1% steps; 100 steps covers the full range either way
+  let best = foreground;
+  let bestRatio = contrastRatio(foreground, background);
+
+  for (let step = 1; step <= 100; step++) {
+    const l = towardsBlack ? startL - step / 100 : startL + step / 100;
+    if (l < 0 || l > 1) break;
+
+    const candidate = hslToRgb(h, s, l);
+    const ratio = contrastRatio(candidate, background);
+    if (ratio > bestRatio) {
+      best = candidate;
+      bestRatio = ratio;
+    }
+    if (ratio >= target) return candidate;
+  }
+
+  // Hue-preserving adjustment could not reach the target (very light
+  // background with a pale color, or vice versa) — return the closest we got,
+  // which is still a large improvement over the original
+  return best;
+}
+
+/** Channel-string form of {@link ensureReadable}. */
+export function ensureReadableChannels(
+  foreground: string,
+  background: string,
+  target: number = AA_TEXT
+): string {
+  return toChannels(ensureReadable(parseRgb(foreground), parseRgb(background), target));
+}
+
+/**
+ * Pick a label color for text sitting on a filled `background`.
+ *
+ * Prefers a hue-preserving shade of the fill itself (a deep amber label on an
+ * amber button), and falls back to black or white when the hue cannot reach the
+ * target — which is what happens with mid-luminance fills.
+ */
+export function readableTextOn(background: string, target: number = AA_TEXT): string {
+  const bg = parseRgb(background);
+  const tinted = ensureReadable(bg, bg, target);
+  if (contrastRatio(tinted, bg) >= target) return toChannels(tinted);
+
+  const white: Rgb = [255, 255, 255];
+  const black: Rgb = [0, 0, 0];
+  return toChannels(contrastRatio(white, bg) >= contrastRatio(black, bg) ? white : black);
+}
+
+/**
+ * Make `foreground` readable against whichever of the given backgrounds is
+ * hardest. Used where one token is rendered on several surfaces — muted text
+ * appears on both the page background and on paper, for instance.
+ */
+export function ensureReadableOnAll(
+  foreground: string,
+  backgrounds: string[],
+  target: number = AA_TEXT
+): string {
+  return backgrounds.reduce(
+    (current, background) => ensureReadableChannels(current, background, target),
+    foreground
+  );
+}
+
+// ── HSL conversion (internal) ───────────────────────────────────────────────
+
+function rgbToHsl(rgb: Rgb): [number, number, number] {
+  const [r, g, b] = rgb.map((c) => c / 255);
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+
+  if (max === min) return [0, 0, l]; // achromatic
+
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h: number;
+  switch (max) {
+    case r: h = ((g - b) / d + (g < b ? 6 : 0)) / 6; break;
+    case g: h = ((b - r) / d + 2) / 6; break;
+    default: h = ((r - g) / d + 4) / 6; break;
+  }
+  return [h, s, l];
+}
+
+function hslToRgb(h: number, s: number, l: number): Rgb {
+  if (s === 0) {
+    const v = Math.round(l * 255);
+    return [v, v, v];
+  }
+
+  const hue2rgb = (p: number, q: number, t: number) => {
+    let tt = t;
+    if (tt < 0) tt += 1;
+    if (tt > 1) tt -= 1;
+    if (tt < 1 / 6) return p + (q - p) * 6 * tt;
+    if (tt < 1 / 2) return q;
+    if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6;
+    return p;
+  };
+
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  return [
+    Math.round(hue2rgb(p, q, h + 1 / 3) * 255),
+    Math.round(hue2rgb(p, q, h) * 255),
+    Math.round(hue2rgb(p, q, h - 1 / 3) * 255),
+  ];
+}

--- a/frontend/src/utils/validation.ts
+++ b/frontend/src/utils/validation.ts
@@ -18,6 +18,24 @@ export function isStrongPassword(password: string): boolean {
   return hasUpperCase && hasLowerCase && hasNumber;
 }
 
+/**
+ * Password rules shown as a live checklist on the pages where a password is
+ * chosen. These mirror `validatePasswordStrength` in the backend exactly — keep
+ * them in step, or the UI will accept passwords the server rejects.
+ */
+export const PASSWORD_REQUIREMENTS: Array<{ test: (p: string) => boolean; label: string }> = [
+  { test: (p) => p.length >= 8,          label: 'At least 8 characters' },
+  { test: (p) => /[A-Z]/.test(p),        label: 'One uppercase letter' },
+  { test: (p) => /[a-z]/.test(p),        label: 'One lowercase letter' },
+  { test: (p) => /[0-9]/.test(p),        label: 'One number' },
+  { test: (p) => /[^A-Za-z0-9]/.test(p), label: 'One special character' },
+];
+
+/** True when every rule in PASSWORD_REQUIREMENTS passes. */
+export function meetsPasswordRequirements(password: string): boolean {
+  return PASSWORD_REQUIREMENTS.every((r) => r.test(password));
+}
+
 export function getPasswordStrength(password: string): {
   score: number;
   label: string;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -29,6 +29,25 @@ export default {
         'danger':       themeColor('--color-danger'),
         'spirit':       themeColor('--color-spirit'),
 
+        // ── Readable text variants ──
+        // The tokens above are fills; these are their text counterparts,
+        // derived per theme so they always clear WCAG AA (see themes.ts
+        // deriveReadableTokens). Use `-ink` whenever the color is TEXT.
+        'brand-ink':    themeColor('--color-brand-ink'),
+        'accent-ink':   themeColor('--color-accent-ink'),
+        'spirit-ink':   themeColor('--color-spirit-ink'),
+        'danger-ink':   themeColor('--color-danger-ink'),
+
+        // ── Semantic states ──
+        // Use these instead of raw Tailwind red/green/amber/blue, which do not
+        // follow the theme (a red-50 panel stays pale pink on a dark theme).
+        'success':      themeColor('--color-success'),
+        'success-ink':  themeColor('--color-success-ink'),
+        'warning':      themeColor('--color-warning'),
+        'warning-ink':  themeColor('--color-warning-ink'),
+        'info':         themeColor('--color-info'),
+        'info-ink':     themeColor('--color-info-ink'),
+
         // ── Legacy aliases (resolve to the same CSS variables) ──
         'moss-green':     themeColor('--color-brand'),
         'forest-shadow':  themeColor('--color-brand-dark'),


### PR DESCRIPTION
Three things that looked fine but weren't.

Theme readability — all 16 built-in themes broke the WCAG AA contrast minimum somewhere, despite themes.ts opening with a promise that they didn't and nothing ever checking. Muted text, the most-used text color in the app, sat between 3.3:1 and 4.4:1 on 13 themes; accent-colored text fell to 1.84:1 on Northern Frost, and headings to 2.60:1 on Shadow Realm. Colors that exist to be fills — accent, spirit, danger, and the new state hues — now have derived `-ink` variants for use as text. A single ensureReadable helper walks a color's lightness until it clears AA against that theme's surfaces, and is shared by the theme tokens, the custom-theme builder, the contrast test and the picker's new readability panel, so none of them can disagree. Authored values that already pass are never altered. Across every theme, text role and surface, 141 unreadable combinations are now zero, with the worst pairing anywhere improved from 1.71:1 to 4.50:1.

Themed surfaces — roughly 850 hardcoded colors across 50 files ignored the theme entirely, so error, success and warning panels rendered as pale pink or washed-out boxes on dark themes, and NPC stat blocks used dark text over a themed panel with no background of their own. Those now use semantic tokens. The character sheets, styled as light paper cards, and the dark DM overlays that float over the map stay deliberately fixed and are documented as exempt — both had their own contrast bugs fixed in place. Two tests keep it this way: 513 assertions covering every preset theme against every text/background pair the UI renders, and a guard that fails if raw palette colors reappear outside the exempt areas.

User invitations — admins could only add someone by generating a temporary password and reading it off the screen, which left them holding a working credential for another account, and nothing ever made the recipient replace it. With SMTP configured, Admin → Users → Invite User now takes just an email address and role: the account is created with no usable password, and the person follows a 7-day link to choose their own, so no credential is generated, shown or emailed. The mustChangePassword flag is finally enforced as well — until an admin-issued password is replaced, every API call except changing it is refused, WebSocket connections are declined, and the app routes the user to a change-password screen. Admin password resets now also sign out the target's existing sessions. Instances without SMTP keep Create User exactly as before.

External proxy documentation — removing the bundled nginx service leaves nothing publishing a port, but "Option A" told readers to publish only the frontend and then point their proxy at localhost:4000, which cannot work. The API either failed outright with a 502, or, when the proxy pointed only at the frontend, returned the SPA's own HTML for every /api call — so a brand-new install showed the login page instead of the setup wizard, and setup failed with a 502. The instructions now publish both services on loopback and explain why the prefix matters, cover all three Cloudflare Tunnel shapes including that ingress rules match in order, and add a troubleshooting section plus docker-compose.override.yml guidance so local edits stop conflicting with git pull.

Also fixed: the Pathfinder and Call of Cthulhu stat block accents never rendered at all, because they were built from dynamic class names Tailwind cannot generate; faint character sheet labels and icons as low as 1.4:1; unreadable hint text on the DM wall, light and fog panels; and a documented health-check command that never worked, since /health is served by the backend and the bundled nginx does not forward it.

No database migration and no configuration changes. Verified by upgrading a 1.1.1 instance in place: existing accounts sign in with their original passwords and are not forced to reset, campaigns, characters and uploaded files are untouched, and saved theme choices including custom colors carry over exactly. Two visual changes are intentional — muted and accent-colored text shifts slightly for legibility, and status panels now tint with the theme instead of always being pale pink or green.
