### PR TITLE
Answer whether CozyVTT can run in a folder

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -351,6 +351,23 @@ docker compose up -d
 
 > One catch: this automatic pickup only happens when you run plain `docker compose` commands. If you pass `-f` yourself, list both files: `docker compose -f docker-compose.yml -f docker-compose.override.yml up -d`.
 
+### Can I run CozyVTT in a folder, like `example.com/cozyvtt/`?
+
+Not at the moment. Give CozyVTT its own web address instead — `cozyvtt.example.com`, or `example.com` itself.
+
+**Why:** the addresses of your maps and token pictures are saved starting with a `/`, which means "the top of this website". Put CozyVTT in a folder and those addresses point one level too high, so none of the pictures load. Changing the *domain* is free for the same reason — the domain was never part of the saved address — which is why moving from one hostname to another just works.
+
+**What to do instead:** add a DNS record for `cozyvtt.example.com` pointing at your server, then match on that hostname rather than a path. In Traefik that means a `Host()` rule instead of `PathPrefix()`:
+
+```yaml
+# instead of:  PathPrefix(`/cozyvtt`)
+- "traefik.http.routers.cozyvtt.rule=Host(`cozyvtt.example.com`)"
+```
+
+It takes about five minutes, and it is the setup CozyVTT is built and tested for.
+
+Running in a folder is on the backlog rather than ruled out. If it matters to you, say so on the issue tracker — how many people need it is what decides whether it gets built.
+
 ---
 
 ## SSL/TLS with Let's Encrypt

--- a/docs/FUTURE_FEATURES.md
+++ b/docs/FUTURE_FEATURES.md
@@ -212,6 +212,26 @@ _Nothing in progress._
   checks on `dev` and `main`, which is a repository setting rather than a file.
   Worth doing the first time the workflow actually runs.
 
+- **Serving the frontend from a folder, like `example.com/cozyvtt/`.** Asked for
+  in #36 by a Traefik user; a subdomain works today and is what the deployment
+  guide now points people at. The easy 10% is Vite's `base` and a router
+  `basename`. The other 90% is that asset addresses are *stored in the database*
+  as `/api/assets/{type}/{id}` (`backend/src/utils/asset-urls.ts`) and read raw at
+  roughly 35 render sites. Writing the prefix into storage puts deployment
+  configuration into user data — a backup restored onto a root-mounted instance
+  would have every picture broken — and it breaks `normalizeAssetUrl`'s
+  `startsWith('/api/assets/')` guard. Adding it at render time instead leaves a
+  rule spread across 35 places that can only be violated silently, on a layout
+  nobody here runs. Note also that `base` is **build-time**, so the runtime env
+  var the issue asked for cannot do it, and the path would end up recorded in
+  four or five places that fail as a blank page whenever two disagree. Roughly
+  4-6 days including a browser test harness the project does not have and would
+  then maintain. **Revisit if** more people ask, or if asset storage is reworked
+  for another reason — the prerequisite is storing bare UUIDs rather than URLs,
+  for which `extractAssetId` already exists on both sides and
+  `backend/src/scripts/migrate-asset-urls.ts` is the precedent, in the opposite
+  direction.
+
 ---
 
 ## Won't Do


### PR DESCRIPTION
Refs #36.

A self-hoster asked whether the frontend can be served under a subpath
(`example.com/cozyvtt/`) the way their other Traefik services are. It can't
today, and until now nothing in the docs said so — you just got a blank page
and no explanation.

Two documents, no code:

- **`docs/DEPLOYMENT.md`** — a "Can I run CozyVTT in a folder?" subsection under
  the reverse-proxy section. Says no for now, explains why in one sentence a
  non-developer can act on (asset addresses are stored starting from the top of
  the site), and gives the concrete Traefik `Host()` rule to use instead.
- **`docs/FUTURE_FEATURES.md`** — a backlog entry under **Polish / tech debt**
  recording why it's expensive (~4-6 days, mostly reworking how asset addresses
  are stored), and the condition for revisiting it.

Filed as backlog, not declined. The issue stays open.